### PR TITLE
feat(requests): add request detail page

### DIFF
--- a/src/api/requestDetail.ts
+++ b/src/api/requestDetail.ts
@@ -1,0 +1,141 @@
+import api from "../lib/api";
+import { RequestComment, RequestCommentAttachment, listRequestComments } from "../features/requestActivity";
+
+export type RequestDetail = {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  priority: string;
+  assignee: string;
+  requester: string;
+  flow: string;
+  dueAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  attachments: RequestCommentAttachment[];
+};
+
+export type RequestActivityEvent = {
+  id: string;
+  actorName: string;
+  verb: string;
+  createdAt: string;
+  payload?: string;
+};
+
+export type RequestDetailBundle = {
+  detail: RequestDetail;
+  comments: RequestComment[];
+  activity: RequestActivityEvent[];
+};
+
+type AttachmentDto = {
+  id?: string;
+  attachmentid?: string;
+  file_name?: string;
+  filename?: string;
+  size?: number;
+  content_type?: string;
+  scan_status?: "pending" | "clean" | "blocked";
+  download_url?: string;
+};
+
+type RequestDetailDto = {
+  requestid?: string;
+  humanid?: string;
+  request_id?: string;
+  human_id?: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  statusid?: string;
+  priority?: string;
+  assignee?: string | null;
+  assignee_name?: string | null;
+  requester?: string | null;
+  requester_name?: string | null;
+  flow?: string;
+  flow_name?: string;
+  due_at?: string;
+  created_at?: string;
+  updated_at?: string;
+  attachments?: AttachmentDto[];
+};
+
+type ActivityDto = {
+  id?: string;
+  activityid?: string;
+  actor_name?: string;
+  actor?: { name?: string };
+  verb?: string;
+  action?: string;
+  created_at?: string;
+  payload?: unknown;
+};
+
+type ActivityResponseDto = {
+  results?: ActivityDto[];
+};
+
+function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
+  return {
+    id: attachment.id ?? attachment.attachmentid ?? crypto.randomUUID(),
+    fileName: attachment.file_name ?? attachment.filename ?? "Attachment",
+    size: attachment.size ?? 0,
+    contentType: attachment.content_type,
+    scanStatus: attachment.scan_status,
+    downloadUrl: attachment.download_url,
+  };
+}
+
+function normalizeDetail(detail: RequestDetailDto): RequestDetail {
+  return {
+    id: detail.human_id ?? detail.humanid ?? detail.request_id ?? detail.requestid ?? "-",
+    title: detail.title ?? "Untitled request",
+    description: detail.description ?? "",
+    status: detail.status ?? detail.statusid ?? "-",
+    priority: detail.priority ?? "-",
+    assignee: detail.assignee_name ?? detail.assignee ?? "-",
+    requester: detail.requester_name ?? detail.requester ?? "-",
+    flow: detail.flow_name ?? detail.flow ?? "-",
+    dueAt: detail.due_at,
+    createdAt: detail.created_at ?? "",
+    updatedAt: detail.updated_at ?? "",
+    attachments: (detail.attachments ?? []).map(normalizeAttachment),
+  };
+}
+
+function normalizeActivity(activity: ActivityDto): RequestActivityEvent {
+  return {
+    id: activity.id ?? activity.activityid ?? crypto.randomUUID(),
+    actorName: activity.actor_name ?? activity.actor?.name ?? "System",
+    verb: activity.verb ?? activity.action ?? "updated request",
+    createdAt: activity.created_at ?? new Date().toISOString(),
+    payload: activity.payload ? JSON.stringify(activity.payload) : undefined,
+  };
+}
+
+export async function getRequestDetail(requestId: string): Promise<RequestDetail> {
+  const response = await api.get<RequestDetailDto>(`/requests/${encodeURIComponent(requestId)}/`);
+  return normalizeDetail(response.data);
+}
+
+export async function getRequestActivity(requestId: string): Promise<RequestActivityEvent[]> {
+  const response = await api.get<ActivityResponseDto | ActivityDto[]>(
+    `/requests/${encodeURIComponent(requestId)}/activity/`,
+    { params: { page_size: 25, sort: "-created_at" } },
+  );
+  const results = Array.isArray(response.data) ? response.data : response.data.results ?? [];
+  return results.map(normalizeActivity);
+}
+
+export async function getRequestDetailBundle(requestId: string): Promise<RequestDetailBundle> {
+  const [detail, comments, activity] = await Promise.all([
+    getRequestDetail(requestId),
+    listRequestComments(requestId),
+    getRequestActivity(requestId),
+  ]);
+
+  return { detail, comments, activity };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from "./auth/useAuth";
 import "./index.css";
 import App from "./pages/App";
 import Login from "./pages/Login";
+import RequestDetailPage from "./pages/RequestDetailPage";
 
 function Protected({ children }: { children: React.ReactNode }) {
   const { token } = useAuth();
@@ -24,6 +25,14 @@ const router = createBrowserRouter([
     element: (
       <Protected>
         <App initialView="search" />
+      </Protected>
+    ),
+  },
+  {
+    path: "/requests/:id",
+    element: (
+      <Protected>
+        <RequestDetailPage />
       </Protected>
     ),
   },

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { AxiosError } from "axios";
 import { HomePage } from "./HomePage";
 import { useAuth } from "../auth/useAuth";
@@ -236,7 +236,13 @@ function FacetGroup({
   );
 }
 
-function SearchResultsTable({ results }: { results: RequestSearchResult[] }) {
+function SearchResultsTable({
+  results,
+  onOpenRequest,
+}: {
+  results: RequestSearchResult[];
+  onOpenRequest(requestId: string): void;
+}) {
   return (
     <div className="card overflow-hidden">
       <div className="grid grid-cols-[130px_1fr_112px_132px_130px_116px] border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-sm font-semibold text-neutral-600">
@@ -249,8 +255,10 @@ function SearchResultsTable({ results }: { results: RequestSearchResult[] }) {
       </div>
       <div>
         {results.map((result) => (
-          <div
+          <button
             key={result.id}
+            type="button"
+            onClick={() => onOpenRequest(result.id)}
             className="grid min-h-12 grid-cols-[130px_1fr_112px_132px_130px_116px] items-center border-b border-neutral-100 px-4 py-2 text-left text-sm last:border-b-0 hover:bg-primary-50"
           >
             <div className="font-semibold text-neutral-800">{result.id}</div>
@@ -275,7 +283,7 @@ function SearchResultsTable({ results }: { results: RequestSearchResult[] }) {
             <div className="truncate pr-4 text-neutral-700">{result.assignee}</div>
             <div className="truncate pr-4 text-neutral-700">{result.flow}</div>
             <div className="text-neutral-700">{result.updatedAt ? formatDate(result.updatedAt) : "-"}</div>
-          </div>
+          </button>
         ))}
       </div>
     </div>
@@ -283,6 +291,7 @@ function SearchResultsTable({ results }: { results: RequestSearchResult[] }) {
 }
 
 function SearchView() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
   const [filters, setFilters] = useState<RequestSearchFilters>({ ...EMPTY_SEARCH_FILTERS, query: initialQuery });
@@ -456,7 +465,12 @@ function SearchView() {
               No requests matched the current search and facets.
             </div>
           )}
-          {!loading && results.length > 0 && <SearchResultsTable results={results} />}
+          {!loading && results.length > 0 && (
+            <SearchResultsTable
+              results={results}
+              onOpenRequest={(requestId) => navigate(`/requests/${encodeURIComponent(requestId)}`)}
+            />
+          )}
           <div className="flex items-center justify-between text-sm text-neutral-600">
             <div>
               Page {filters.page} of {totalPages}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -284,10 +284,7 @@ export function HomePage() {
       {!listLoading && requests.length > 0 && (
         <RequestTable
           requests={requests}
-          onOpenRequest={(requestId) => {
-            console.log("Open request", requestId);
-            alert("Request detail page coming next.");
-          }}
+          onOpenRequest={(requestId) => navigate(`/requests/${encodeURIComponent(requestId)}`)}
         />
       )}
     </section>

--- a/src/pages/RequestDetailPage.tsx
+++ b/src/pages/RequestDetailPage.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { RequestActivityEvent, RequestDetail, getRequestDetailBundle } from "../api/requestDetail";
+import { EmptyState } from "../components/common/EmptyState";
+import { ErrorState } from "../components/common/ErrorState";
+import { PriorityChip } from "../components/requests/PriorityChip";
+import { StatusBadge } from "../components/requests/StatusBadge";
+import { RequestComment } from "../features/requestActivity";
+
+const FALLBACK_DETAIL: RequestDetail = {
+  id: "RT-2025-001001",
+  title: "VPN not connecting",
+  description: "User cannot connect after password rotation. VPN client reports invalid profile.",
+  status: "Open",
+  priority: "High",
+  assignee: "Ana Gomez",
+  requester: "Carlos Diaz",
+  flow: "IT Support",
+  dueAt: "2025-08-23T17:00:00Z",
+  createdAt: "2025-08-22T08:25:00Z",
+  updatedAt: "2025-08-22T10:41:00Z",
+  attachments: [
+    {
+      id: "attachment-001",
+      fileName: "vpn-error-screenshot.png",
+      size: 248_120,
+      contentType: "image/png",
+      scanStatus: "clean",
+    },
+  ],
+};
+
+const FALLBACK_COMMENTS: RequestComment[] = [
+  {
+    id: "comment-001",
+    authorName: "Ana Gomez",
+    body: "Confirmed the VPN profile fails after password rotation. Waiting on network team review.",
+    createdAt: "2025-08-22T11:20:00Z",
+    attachments: FALLBACK_DETAIL.attachments,
+  },
+];
+
+const FALLBACK_ACTIVITY: RequestActivityEvent[] = [
+  {
+    id: "activity-001",
+    actorName: "Carlos Diaz",
+    verb: "created request",
+    createdAt: "2025-08-22T08:25:00Z",
+  },
+  {
+    id: "activity-002",
+    actorName: "Ana Gomez",
+    verb: "added comment",
+    createdAt: "2025-08-22T11:20:00Z",
+  },
+];
+
+function formatDate(value?: string) {
+  if (!value || Number.isNaN(Date.parse(value))) return "-";
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatFileSize(size: number) {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase text-neutral-500">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-neutral-900">{value}</div>
+    </div>
+  );
+}
+
+function CommentsSection({ comments }: { comments: RequestComment[] }) {
+  if (comments.length === 0) {
+    return <EmptyState title="No comments yet." body="Conversation updates will appear here." />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {comments.map((comment) => (
+        <article key={comment.id} className="rounded-lg border border-neutral-200 bg-white p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="font-semibold text-neutral-900">{comment.authorName}</div>
+            <time className="text-xs text-neutral-500">{formatDate(comment.createdAt)}</time>
+          </div>
+          {comment.body && <p className="mt-2 whitespace-pre-wrap text-sm text-neutral-800">{comment.body}</p>}
+          {comment.attachments.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {comment.attachments.map((attachment) => (
+                <span
+                  key={attachment.id}
+                  className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-xs font-semibold text-neutral-700"
+                >
+                  {attachment.fileName}
+                </span>
+              ))}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function AttachmentsSection({ detail, comments }: { detail: RequestDetail; comments: RequestComment[] }) {
+  const attachments = useMemo(() => {
+    const byId = new Map(detail.attachments.map((attachment) => [attachment.id, attachment]));
+    comments.forEach((comment) => {
+      comment.attachments.forEach((attachment) => byId.set(attachment.id, attachment));
+    });
+    return Array.from(byId.values());
+  }, [comments, detail.attachments]);
+
+  if (attachments.length === 0) {
+    return <EmptyState title="No attachments." body="Clean scanned files will appear here once uploaded." />;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {attachments.map((attachment) => (
+        <div key={attachment.id} className="rounded-lg border border-neutral-200 bg-white p-3">
+          <div className="truncate text-sm font-semibold text-neutral-900">{attachment.fileName}</div>
+          <div className="mt-1 text-xs text-neutral-600">
+            {formatFileSize(attachment.size)}
+            {attachment.scanStatus ? ` - scan ${attachment.scanStatus}` : ""}
+          </div>
+          {attachment.downloadUrl && (
+            <a
+              href={attachment.downloadUrl}
+              className="mt-2 inline-block text-sm font-semibold text-primary-700 hover:text-primary-600"
+            >
+              Open
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActivitySection({ events }: { events: RequestActivityEvent[] }) {
+  if (events.length === 0) {
+    return <EmptyState title="No activity yet." body="Request history will appear here." />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {events.map((event) => (
+        <div key={event.id} className="rounded-lg border border-neutral-200 bg-white p-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm text-neutral-900">
+              <span className="font-semibold">{event.actorName}</span> {event.verb}
+            </div>
+            <time className="text-xs text-neutral-500">{formatDate(event.createdAt)}</time>
+          </div>
+          {event.payload && <div className="mt-2 text-xs text-neutral-600">{event.payload}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function RequestDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const requestId = id ?? "";
+  const [detail, setDetail] = useState<RequestDetail | null>(null);
+  const [comments, setComments] = useState<RequestComment[]>([]);
+  const [activity, setActivity] = useState<RequestActivityEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadDetail() {
+      if (!requestId) return;
+      setLoading(true);
+      try {
+        const bundle = await getRequestDetailBundle(requestId);
+        if (cancelled) return;
+        setDetail(bundle.detail);
+        setComments(bundle.comments);
+        setActivity(bundle.activity);
+        setError(null);
+      } catch {
+        if (cancelled) return;
+        setDetail({ ...FALLBACK_DETAIL, id: requestId });
+        setComments(FALLBACK_COMMENTS);
+        setActivity(FALLBACK_ACTIVITY);
+        setError("Could not load request detail from API. Showing local demo data.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [requestId]);
+
+  if (!detail && loading) {
+    return <div className="p-6 text-sm text-neutral-500">Loading request detail...</div>;
+  }
+
+  if (!detail) {
+    return <ErrorState message="Request detail is unavailable." onRetry={() => navigate("/")} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-b border-neutral-200 bg-white px-6 py-4">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="mb-3 rounded-lg border border-neutral-300 px-3 py-2 text-sm font-semibold text-neutral-700 hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+        >
+          Back
+        </button>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-sm font-semibold text-neutral-500">{detail.id}</div>
+            <h1 className="mt-1 text-2xl font-semibold text-neutral-900">{detail.title}</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <StatusBadge status={detail.status} />
+            <PriorityChip priority={detail.priority} />
+          </div>
+        </div>
+      </header>
+
+      <main className="grid grid-cols-[minmax(0,1fr)_320px] gap-4 p-6">
+        <div className="space-y-4">
+          {error && <ErrorState message={error} />}
+
+          <section className="card p-4">
+            <h2 className="text-lg font-semibold text-neutral-900">Details</h2>
+            <p className="mt-3 whitespace-pre-wrap text-sm text-neutral-800">
+              {detail.description || "No description provided."}
+            </p>
+          </section>
+
+          <section className="card p-4">
+            <h2 className="text-lg font-semibold text-neutral-900">Comments</h2>
+            <div className="mt-3">
+              <CommentsSection comments={comments} />
+            </div>
+          </section>
+
+          <section className="card p-4">
+            <h2 className="text-lg font-semibold text-neutral-900">Attachments</h2>
+            <div className="mt-3">
+              <AttachmentsSection detail={detail} comments={comments} />
+            </div>
+          </section>
+
+          <section className="card p-4">
+            <h2 className="text-lg font-semibold text-neutral-900">Activity</h2>
+            <div className="mt-3">
+              <ActivitySection events={activity} />
+            </div>
+          </section>
+        </div>
+
+        <aside className="card h-fit space-y-4 p-4">
+          <DetailField label="Status" value={detail.status} />
+          <DetailField label="Priority" value={detail.priority} />
+          <DetailField label="Assignee" value={detail.assignee} />
+          <DetailField label="Requester" value={detail.requester} />
+          <DetailField label="Flow" value={detail.flow} />
+          <DetailField label="Due Date" value={formatDate(detail.dueAt)} />
+          <DetailField label="Created" value={formatDate(detail.createdAt)} />
+          <DetailField label="Updated" value={formatDate(detail.updatedAt)} />
+        </aside>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Sprint 2 Day 1-2 Request Detail page and navigation from Home/Search rows.

## Changes
- Adds `/requests/:id` protected route.
- Adds request detail API adapter for detail, comments, and activity timeline data.
- Adds full Request Detail page with header, details, comments, attachments, activity timeline, and right metadata sidebar.
- Home request rows and Search results now navigate to request detail.
- Keeps local fallback data for demo mode when the API is unavailable.

## Acceptance Criteria
- [x] Clicking a request from Home opens Request Detail
- [x] Clicking a request from Search opens Request Detail
- [x] Comments display on Request Detail
- [x] Attachments display on Request Detail
- [x] Activity timeline displays request events
- [x] Tenant/auth headers included through the existing Axios interceptor
- [x] Loading/error/fallback states exist

## Testing notes
- [x] `tsc --noEmit`
- [x] `eslint .`
- [x] `vite build`
- [x] Smoke route `/`
- [x] Smoke route `/search?q=vpn`
- [x] Smoke route `/requests/RT-2025-001001`

## API alignment
The frontend currently expects:
- `GET /requests/:id/`
- `GET /requests/:id/comments/`
- `GET /requests/:id/activity/`

Fallback data is shown if these are unavailable during local demo.