### PR TITLE
docs(codex): add planning and execution guidance

### DIFF
--- a/.agent/PLANS.md
+++ b/.agent/PLANS.md
@@ -1,0 +1,75 @@
+# PLANS.md — Codex ExecPlans Standard
+
+This file defines how Codex must create and maintain ExecPlans in this repository.
+
+An ExecPlan is a self-contained implementation plan that a coding agent or a new engineer can follow without needing hidden chat context. Use an ExecPlan for complex features, cross-file refactors, security-sensitive changes, workflow changes, or any task expected to affect multiple modules.
+
+## Non-negotiable rules
+
+1. Read this file and the repository `AGENTS.md` in full before creating or executing an ExecPlan.
+2. Every ExecPlan must be self-contained. Do not rely on prior chat memory.
+3. Every ExecPlan must explain the user-visible outcome first.
+4. Every ExecPlan must name exact repository-relative files and commands.
+5. Every ExecPlan must contain acceptance criteria and verification steps.
+6. Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` updated.
+7. For API or UI contract changes, update OpenAPI or design tokens before implementation.
+8. Run the repo checks listed in `AGENTS.md` before suggesting a commit or PR.
+9. For auth, tenancy, uploads, search SQL, database, permissions, or workflows, include negative tests.
+
+## Where plans live
+
+- Shared standard: `.agent/PLANS.md`
+- Active plans: `docs/plans/sprint-<n>/<feature>-execplan.md`
+- Temporary plans: `.agent/tmp/` and must not be committed unless promoted.
+
+## ExecPlan skeleton
+
+# <Short action-oriented feature title>
+
+## Purpose
+
+Explain what a user or operator can do after this change that they cannot do now. Include how to observe it working.
+
+## Repository orientation
+
+Explain the relevant files and folders in this repo. Name exact repository-relative paths.
+
+## Current behavior
+
+Describe what the app does today.
+
+## Desired behavior
+
+Describe target behavior, edge cases, failure behavior, and security expectations.
+
+## Scope
+
+State what is in scope and out of scope.
+
+## Implementation plan
+
+Write step-by-step milestones. Each milestone names files to edit, commands to run, and expected observations.
+
+## Tests and verification
+
+List unit, integration, manual, Postman, or browser checks. Include exact commands.
+
+## Acceptance criteria
+
+Use behavior-oriented criteria.
+
+## Progress
+
+Use checkboxes and keep updated.
+
+## Surprises & Discoveries
+
+Record facts discovered during implementation.
+
+## Decision Log
+
+Record decisions and why they were made.
+
+## Outcomes & Retrospective
+
+At completion, summarize what changed, what works, what remains, and follow-up issues.

--- a/.agent/code_review.md
+++ b/.agent/code_review.md
@@ -1,0 +1,20 @@
+# code_review.md — Codex Review Standard
+
+Use this checklist when asking Codex to review a branch, PR diff, uncommitted changes, or a commit.
+
+## Review priorities
+
+1. Correctness: Does the change implement the requested behavior?
+2. Tenant isolation: Can one tenant access another tenant's data?
+3. Security: Are auth, permissions, uploads, SQL, and secrets handled safely?
+4. API contract: Does public JSON use clean fields like `request_id`, `flow_id`, `created_at`?
+5. Error handling: Are client mistakes returned as 400/401/403/404 instead of 500?
+6. Tests: Are relevant tests added or updated?
+7. Maintainability: Is logic in the correct service/component layer?
+8. UX: Are loading, empty, error, and success states handled?
+9. Documentation: Are OpenAPI, README, or demo docs updated?
+10. Regression risk: What existing behavior might break?
+
+## Codex review prompt
+
+Review this branch against `main`. Read `AGENTS.md`, `.agent/PLANS.md`, and the active ExecPlan in `docs/plans` first. Focus on correctness, tenant isolation, public API naming, test coverage, and regressions. Do not make code changes yet. Return prioritized findings with file paths and suggested fixes.

--- a/.codex/config.toml.example
+++ b/.codex/config.toml.example
@@ -1,0 +1,8 @@
+# .codex/config.toml.example
+# Copy to .codex/config.toml if you want repo-local Codex defaults.
+# Keep approvals and sandboxing conservative unless you intentionally loosen them.
+# Recommended project style:
+# - Plan first for multi-file features.
+# - Ask before destructive operations.
+# - Run repo-specific checks before suggesting a commit.
+# - Keep changes small and PR-focused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,20 @@
 - Optional OpenSearch backend for search with query DSL.
 - SSO/OIDC path with well-known discovery; keep JWT as fallback for dev.
 
+## 15. Codex ExecPlans
+
+For complex features, multi-file refactors, security-sensitive changes, API contract changes, database changes, upload/search changes, or Sprint work, Codex must create or update an ExecPlan following `.agent/PLANS.md`.
+
+ExecPlans must live under `docs/plans/`. The active ExecPlan must be updated throughout implementation, especially `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective`.
+
+For small single-file fixes, an ExecPlan is optional, but Codex must still state goal, constraints, and done criteria before editing.
+
+Before implementation, Codex must read:
+1. `AGENTS.md`
+2. `.agent/PLANS.md`
+3. the active ExecPlan for the branch
+4. any repo-specific design/API/token files referenced by the plan
+
 ---
 
 *This AGENTS.md reflects the design and constraints agreed for the Request Tracker modernization project.*

--- a/docs/codex-prompts.md
+++ b/docs/codex-prompts.md
@@ -1,0 +1,13 @@
+# Codex prompts — rt-web
+
+## Plan Day 3–4
+
+Read `AGENTS.md` and `.agent/PLANS.md` in full. Update `docs/plans/sprint-2/web-full-request-lifecycle-execplan.md`. The next milestones are Create Request and Request Detail integration. Do not write code yet.
+
+## Implement next milestone
+
+Read `AGENTS.md`, `.agent/PLANS.md`, and the active ExecPlan. Implement only the next unchecked milestone. Keep the ExecPlan updated. Run `pnpm lint` and `pnpm build`.
+
+## Review
+
+Review this branch against `main` using `.agent/code_review.md`. Focus on route behavior, auth headers, X-Tenant, UX states, API field naming assumptions, and UI consistency.

--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -1,0 +1,71 @@
+# Sprint 2 Web ExecPlan — Full Request Lifecycle UI
+
+## Purpose
+
+This plan completes the frontend request lifecycle. After the change, users can create a request, open a complete Request Detail page, add comments and attachments, transition or close a request, see dashboard summary counts, and manage simple profile/preferences.
+
+## Repository orientation
+
+This plan applies to `rt-web`. Relevant areas: `src/pages/`, `src/components/`, `src/api.ts` or `src/api/`, `design/design-tokens.json`, Tailwind config, `AGENTS.md`, and `.agent/PLANS.md`.
+
+## Current behavior
+
+Sprint 1 has login, shell, Home, Search, comments/uploads, and user menu. Request Detail and Create Request are not full user flows.
+
+## Desired behavior
+
+Users navigate from Home/Search to `/requests/:id`, see details, comments, attachments, and activity, create a request from `/requests/new`, and transition or close it from detail.
+
+## Scope
+
+In scope: Request Detail page, Create Request flow, transition/close UI, dashboard summary integration, basic profile/preferences, loading/empty/error states. Out of scope: admin workflow builder, OIDC/AD, WebSockets.
+
+## Implementation plan
+
+### Milestone 1: Request Detail route
+
+Create `/requests/:id`, API client calls, header, details, comments, attachments, and activity timeline.
+
+### Milestone 2: Create Request flow
+
+Create `/requests/new` or modal. Fields: title, description, flow, initial status, priority, assignee, tags, due date. On success, navigate to detail.
+
+### Milestone 3: Transitions and close
+
+Fetch available transitions, render actions, support optional transition comment, and refresh detail after success.
+
+### Milestone 4: Dashboard summary integration
+
+Replace multiple count calls with `GET /api/dashboard/summary/` when available.
+
+### Milestone 5: User profile/preferences
+
+Add profile/preferences route or panel from user menu with display name, email, employee code, tenant info, and placeholder theme/density controls.
+
+## Tests and verification
+
+Run `pnpm lint` and `pnpm build`. Manually verify login, Home, create request, detail, comment/upload, transition/close, search, profile, logout.
+
+## Acceptance criteria
+
+Request Detail exists; Create Request works; transition/close works; dashboard summary is consumed; profile/preferences exists; states are implemented; UI follows tokens; auth and X-Tenant headers are sent.
+
+## Progress
+
+- [ ] Milestone 1 completed.
+- [ ] Milestone 2 completed.
+- [ ] Milestone 3 completed.
+- [ ] Milestone 4 completed.
+- [ ] Milestone 5 completed.
+
+## Surprises & Discoveries
+
+Record findings here.
+
+## Decision Log
+
+Record decisions here.
+
+## Outcomes & Retrospective
+
+Complete after merge.

--- a/docs/plans/sprint-3/web-admin-configuration-execplan.md
+++ b/docs/plans/sprint-3/web-admin-configuration-execplan.md
@@ -1,0 +1,11 @@
+# Sprint 3 Web ExecPlan — Admin and Configuration UI
+
+Purpose: add admin UI for workflows, users, roles, and permissions.
+
+Progress:
+- [ ] Admin shell and route guards.
+- [ ] Workflow list/detail/edit screens.
+- [ ] User/membership screens.
+- [ ] Role/permission matrix.
+- [ ] UX hardening and tests.
+


### PR DESCRIPTION
## Summary
Adds Codex best-practices and ExecPlan guidance for future RT development work.

## Changes
- Adds Codex planning/ExecPlan guidance under `.agent/`.
- Adds code review and prompt guidance docs.
- Adds Sprint 2 and Sprint 3 execution plans under `docs/plans/`.
- Updates `AGENTS.md` to require ExecPlans for complex, security-sensitive, API, upload/search, and sprint work.
- Adds an example `.codex/config.toml.example` for local Codex configuration.

## Testing notes
- Docs/config guidance only; no app runtime behavior changes.
- Verified staged scope is limited to `.agent`, `.codex`, `docs`, and `AGENTS.md`.

## Checklist
- [x] Docs-only change
- [x] Conventional Commit title
- [x] No app source/runtime files changed