### PR TITLE
feat(requests): add create request flow

### DIFF
--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -10,11 +10,11 @@ This plan applies to `rt-web`. Relevant areas: `src/pages/`, `src/components/`, 
 
 ## Current behavior
 
-Sprint 1 has login, shell, Home, Search, comments/uploads, and user menu. Request Detail and Create Request are not full user flows.
+Sprint 1 has login, shell, Home, Search, comments/uploads, and user menu. Sprint 2 Day 1-2 added a protected Request Detail route at `/requests/:id`, navigation from Home/Search rows to detail, and a detail API adapter that uses the shared tenant/auth Axios client. Create Request is not yet a full user flow: the top bar and Home page `New Request` buttons still show placeholder alerts, and there is no `/requests/new` route.
 
 ## Desired behavior
 
-Users navigate from Home/Search to `/requests/:id`, see details, comments, attachments, and activity, create a request from `/requests/new`, and transition or close it from detail.
+Users navigate from Home/Search to `/requests/:id`, see details, comments, attachments, and activity, create a request from `/requests/new`, and transition or close it from detail. Day 3-4 specifically delivers a protected create page with validation states, API submission through the shared Axios client, and navigation to the created Request Detail page after success.
 
 ## Scope
 
@@ -28,7 +28,44 @@ Create `/requests/:id`, API client calls, header, details, comments, attachments
 
 ### Milestone 2: Create Request flow
 
-Create `/requests/new` or modal. Fields: title, description, flow, initial status, priority, assignee, tags, due date. On success, navigate to detail.
+User-visible outcome: a signed-in user can click `New Request`, complete a compact create form, see inline validation, submit it through the API, and land on `/requests/:id` for the created request.
+
+Implementation steps:
+
+1. Add a protected route in `src/main.tsx`:
+   - Path: `/requests/new`
+   - Element: `RequestCreatePage`
+   - Reuse the existing `Protected` wrapper so unauthenticated users are redirected to `/login`.
+2. Replace placeholder `New Request` alerts with navigation:
+   - In `src/pages/App.tsx`, make the top bar `New Request` action navigate to `/requests/new`.
+   - In `src/pages/HomePage.tsx`, make the Home `New Request` action navigate to `/requests/new`.
+   - Keep left rail `New Request` behavior consistent with the top bar if it is wired during this milestone.
+3. Create `src/api/requestCreate.ts`:
+   - Export `CreateRequestPayload`, `CreateRequestResult`, and `createRequest(payload)`.
+   - Use the shared `src/lib/api.ts` Axios instance so `Authorization` and `X-Tenant` headers are included automatically.
+   - Call `POST /requests/`.
+   - Send API field names: `flow_id`, `status_id`, `requester_id`, and `assignee_id`; never send display-only field names such as `flow`, `requester`, or `assignee`.
+   - Send `priority` as a lowercase value: `low`, `normal`, `high`, or `urgent`.
+   - Read the public `request_id` from the create response and use only that value for post-create detail navigation.
+4. Create `src/pages/RequestCreatePage.tsx`:
+   - Use a full page, not a modal, for this milestone. This keeps the create flow bookmarkable and easier to validate manually.
+   - Fields: `title` required, `description` required, `flow_id` required, `status_id` loaded from selected flow, `priority`, `assignee_id`, `requester_id`, `tags`, and `due_at`.
+   - Use top labels, helper text, required asterisks, focus-visible outlines, and `danger-500` error text per `AGENTS.md`.
+   - Use Tailwind tokens already exposed in `design/design-tokens.json` and `tailwind.config.ts`; do not introduce hardcoded palette values outside the existing token classes.
+5. Validation behavior:
+   - Disable submit while posting.
+   - Required field errors appear inline under fields after submit attempt or blur.
+   - When `flow_id` changes, load statuses for that flow, select the Open status by default, and block submit if no Open `status_id` is available.
+   - API errors render in the repo error shape if available: `code`, `message`, `details[]`; map backend fields such as `flow_id`, `status_id`, `requester_id`, and `assignee_id` to readable labels in form-level or inline errors.
+   - Do not navigate on validation or API failure.
+6. Success behavior:
+   - After `createRequest` succeeds, navigate to `/requests/${encodeURIComponent(created.requestId)}`.
+   - Do not navigate with `human_id`, `humanid`, `requestid`, internal `id`, `null`, or `undefined`.
+   - If `request_id` is not returned, show a non-field error and stay on the form.
+7. Out-of-scope for this milestone:
+   - Attachment upload during creation.
+   - Workflow transitions or closing.
+   - Loading flow/user option lists from admin APIs. Use simple inputs or static options until API endpoints are confirmed.
 
 ### Milestone 3: Transitions and close
 
@@ -44,28 +81,80 @@ Add profile/preferences route or panel from user menu with display name, email, 
 
 ## Tests and verification
 
-Run `pnpm lint` and `pnpm build`. Manually verify login, Home, create request, detail, comment/upload, transition/close, search, profile, logout.
+Run `pnpm lint`, `pnpm typecheck`, and `pnpm build` where available. Manually verify login, Home, create request, detail, comment/upload, transition/close, search, profile, logout.
+
+Milestone 2 exact manual verification:
+
+1. Start API and web.
+2. Log in with a valid tenant.
+3. From `/`, click the top bar `New Request`.
+4. Confirm the app navigates to `/requests/new`.
+5. Submit an empty form.
+6. Confirm inline required errors appear for title, description, and flow; confirm no API request succeeds and the URL remains `/requests/new`.
+7. Fill required fields and optional priority, assignee, requester, tags, and due date.
+8. Submit the form.
+9. Confirm the request is created through `POST /requests/` with `Authorization` and `X-Tenant` headers.
+10. Confirm submit is disabled while posting.
+11. Confirm success navigates to `/requests/:id`.
+12. In Chrome DevTools Network, confirm `POST /api/requests/` returns `201` with `response.request_id`, the browser navigates to `/requests/{request_id}`, and the detail `GET` returns `200`.
+13. Return Home and confirm the Home page `New Request` button also navigates to `/requests/new`.
+14. If the API returns validation errors, confirm they render inline or in a form-level error without navigating.
 
 ## Acceptance criteria
 
 Request Detail exists; Create Request works; transition/close works; dashboard summary is consumed; profile/preferences exists; states are implemented; UI follows tokens; auth and X-Tenant headers are sent.
 
+Milestone 2 acceptance criteria:
+
+- `/requests/new` is protected and available through top bar and Home `New Request` actions.
+- Create form includes title, description, flow, priority, assignee, requester, tags, and due date inputs.
+- Required-field validation states are visible and accessible.
+- API submission uses `POST /requests/` through the shared Axios client and sends `flow_id`, `status_id`, `requester_id`, optional `assignee_id`, lowercase `priority`, `tags`, and `due_at`.
+- API and validation failures keep the user on the form and show clear errors.
+- Successful creation navigates to `/requests/{request_id}` using the create response `request_id`.
+- Request Detail renders real API data after a successful detail `GET` and does not show demo fallback messaging in authenticated API flows.
+- Request Detail normalizes nested API objects and renders `flow.name`, `status.name`, `requester.display_name/email`, and `assignee.display_name/email` or `Unassigned`; it never renders raw objects in JSX.
+- Home and Search rows navigate with `request.request_id`; rows without `request_id` do not navigate to `/requests/-`.
+- No attachment upload, transition, or close behavior is introduced in this milestone.
+
 ## Progress
 
-- [ ] Milestone 1 completed.
-- [ ] Milestone 2 completed.
+- [x] Milestone 1 completed.
+- [x] Milestone 2 completed.
 - [ ] Milestone 3 completed.
 - [ ] Milestone 4 completed.
 - [ ] Milestone 5 completed.
 
 ## Surprises & Discoveries
 
-Record findings here.
+- 2026-05-30: Current routes are `/`, `/search`, and `/requests/:id`; `/requests/new` does not exist yet.
+- 2026-05-30: Top bar and Home `New Request` actions are still placeholder alerts.
+- 2026-05-30: `src/lib/api.ts` centralizes auth and tenancy headers with `Authorization: Bearer <token>` and `X-Tenant`.
+- 2026-05-30: Design tokens are available through Tailwind classes mapped from `design/design-tokens.json`; status/priority UI components already exist under `src/components/requests/`.
+- 2026-05-30: Create Request can be implemented without new dependencies; current React Router setup supports adding `/requests/new` beside `/requests/:id`.
+- 2026-05-30: The API response ID normalizer must tolerate both public field names (`human_id`, `request_id`) and current legacy frontend names (`humanid`, `requestid`).
+- 2026-05-30: Backend validation rejects the original create payload because it used `flow`, `requester`, and `assignee`; the create endpoint expects `flow_id`, `status_id`, `requester_id`, and `assignee_id`.
+- 2026-05-30: Priority labels can stay user-friendly in the UI, but submitted values must be lowercase: `low`, `normal`, `high`, or `urgent`.
+- 2026-05-30: `/requests/new` must be registered before `/requests/:id`; otherwise React Router treats `new` as a request ID.
+- 2026-05-30: The create endpoint returns the public `request_id`; navigating with human/legacy IDs causes the detail route to miss the newly created SQL Server row and show the old demo-data fallback.
+- 2026-05-30: Request Detail should treat the detail API response as authoritative. Comment or activity fetch failures can show empty sections, but a `200` detail response should still render real request data.
+- 2026-05-30: Detail responses now include nested `flow`, `status`, `requester`, and nullable `assignee` objects. Rendering those fields directly crashes React, so adapters must flatten them to display strings before JSX.
+- 2026-05-30: Home/Search list rows need a distinct `requestId` route key from the display `id`; using `id`, `human_id`, or `-` can route users to `/requests/-` or the wrong detail URL.
 
 ## Decision Log
 
-Record decisions here.
+- 2026-05-30: Use a full `/requests/new` route instead of a modal for Create Request. This supports direct navigation, simpler validation, and easier manual smoke testing.
+- 2026-05-30: Use `POST /requests/` for creation because existing request list/detail APIs are under `/requests/` and the frontend already uses the shared Axios client for tenant/auth headers.
+- 2026-05-30: Defer create-time attachments until after the base create flow is stable; attachments already exist in the comment/upload flow.
+- 2026-05-30: Use simple text inputs/static priority options for flow, assignee, requester, and tags until API endpoints for option lists are confirmed.
+- 2026-05-30: Treat flow, requester, and assignee inputs as ID inputs for now. The UI can later replace these with name-based selectors, but the payload must remain ID-based.
+- 2026-05-30: Load flow statuses from `/flows/:flowId/statuses/` on flow selection and send the Open `status_id` by default.
+- 2026-05-30: Omit empty optional fields where appropriate and send blank assignee as `assignee_id: null`, not an empty string.
+- 2026-05-30: Post-create navigation uses only `response.request_id` from `POST /requests/`. If that field is missing, the form shows an error and does not guess from `human_id`, `requestid`, or internal IDs.
+- 2026-05-30: Disable the Request Detail demo-data fallback by default. It is now available only when `VITE_ENABLE_DEMO_DETAIL_FALLBACK=true`; authenticated API flows show a clear error state instead.
+- 2026-05-30: Normalize nested request detail/list/search fields at API adapter boundaries. Components receive strings for flow, status, requester, and assignee, plus optional `statusCategory` for badge styling.
+- 2026-05-30: Keep table display IDs separate from route IDs. Home and Search route with `request_id` only and disable row activation when that value is missing.
 
 ## Outcomes & Retrospective
 
-Complete after merge.
+Milestone 2 outcome: `/requests/new` now exists as a protected full-page create flow. Top bar, left rail, and Home `New Request` actions navigate to it. The form validates title, description, flow ID, requester ID, and Open status ID before submission, sends `POST /requests/` through the shared Axios client, renders API/form errors without navigating, disables submit while posting, and navigates to `/requests/{request_id}` only when the API returns the public `request_id`. The payload now uses backend field names (`flow_id`, `status_id`, `requester_id`, `assignee_id`) and lowercase priority values. Request Detail loads real API data through the shared Axios client, normalizes nested detail objects into display strings, and no longer shows demo fallback messaging by default. Home and Search row navigation now use `request_id` instead of display IDs and avoid routing missing IDs to `/requests/-`. Create-time attachments, workflow transitions, and close behavior remain deferred to later milestones.

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -2,8 +2,10 @@ import api from "../lib/api";
 
 export type DashboardRequest = {
   id: string;
+  requestId: string;
   title: string;
   status: string;
+  statusCategory?: string;
   priority: string;
   assignee: string;
   requester: string;
@@ -37,16 +39,18 @@ export type DashboardListResponse = {
 type RequestDto = {
   requestid?: string;
   humanid?: string;
+  request_id?: string;
+  human_id?: string;
   title?: string;
   statusid?: string;
-  status?: string;
+  status?: string | StatusDto | null;
   priority?: string;
-  assignee?: string | null;
+  assignee?: string | UserDto | null;
   assignee_name?: string | null;
-  requester?: string | null;
+  requester?: string | UserDto | null;
   requester_name?: string | null;
   updated_at?: string;
-  flow?: string;
+  flow?: string | FlowDto | null;
   flow_name?: string;
   due_at?: string;
 };
@@ -56,16 +60,60 @@ type RequestListDto = {
   count?: number;
 };
 
+type FlowDto = {
+  flow_id?: string;
+  name?: string;
+  description?: string;
+};
+
+type StatusDto = {
+  status_id?: string;
+  name?: string;
+  category?: string;
+  is_terminal?: boolean;
+};
+
+type UserDto = {
+  user_id?: string;
+  email?: string;
+  display_name?: string;
+  employee_code?: string;
+  avatar_url?: string;
+};
+
+function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
+  if (typeof flow === "string") return flow;
+  return flow?.name ?? fallback ?? "-";
+}
+
+function displayStatus(status?: string | StatusDto | null, fallback?: string) {
+  if (typeof status === "string") return status;
+  return status?.name ?? fallback ?? "-";
+}
+
+function statusCategory(status?: string | StatusDto | null) {
+  if (!status || typeof status === "string") return undefined;
+  return status.category;
+}
+
+function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
+  if (typeof user === "string") return user;
+  return user?.display_name ?? user?.email ?? fallback ?? empty;
+}
+
 function normalizeRequest(request: RequestDto): DashboardRequest {
+  const requestId = request.request_id ?? "";
   return {
-    id: request.humanid ?? request.requestid ?? "-",
+    id: (request.human_id ?? request.humanid ?? requestId) || request.requestid || "-",
+    requestId,
     title: request.title ?? "Untitled request",
-    status: request.status ?? request.statusid ?? "-",
+    status: displayStatus(request.status, request.statusid),
+    statusCategory: statusCategory(request.status),
     priority: request.priority ?? "-",
-    assignee: request.assignee_name ?? request.assignee ?? "-",
-    requester: request.requester_name ?? request.requester ?? "-",
+    assignee: displayUser(request.assignee, request.assignee_name, "Unassigned"),
+    requester: displayUser(request.requester, request.requester_name),
     updatedAt: request.updated_at ?? "",
-    flow: request.flow_name ?? request.flow,
+    flow: displayFlow(request.flow, request.flow_name),
     dueAt: request.due_at,
   };
 }

--- a/src/api/requestCreate.ts
+++ b/src/api/requestCreate.ts
@@ -1,0 +1,78 @@
+import api from "../lib/api";
+
+export type CreateRequestPayload = {
+  title: string;
+  description: string;
+  flow_id: string;
+  status_id: string;
+  priority?: string;
+  requester_id: string;
+  assignee_id?: string | null;
+  tags?: string[];
+  due_at?: string;
+};
+
+export type CreateRequestResult = {
+  requestId: string;
+  title: string;
+};
+
+type CreateRequestDto = {
+  requestid?: string;
+  humanid?: string;
+  request_id?: string;
+  human_id?: string;
+  title?: string;
+};
+
+type StatusDto = {
+  id?: string;
+  status_id?: string;
+  statusid?: string;
+  name?: string;
+  label?: string;
+  category?: string;
+  status_category?: string;
+  is_open?: boolean;
+};
+
+type StatusListDto = {
+  results?: StatusDto[];
+};
+
+export type FlowStatus = {
+  id: string;
+  name: string;
+  category: string;
+  isOpen: boolean;
+};
+
+function normalizeCreatedRequest(data: CreateRequestDto): CreateRequestResult {
+  return {
+    requestId: data.request_id ?? "",
+    title: data.title ?? "Untitled request",
+  };
+}
+
+function normalizeStatus(status: StatusDto): FlowStatus {
+  const category = status.category ?? status.status_category ?? "";
+  const name = status.name ?? status.label ?? category ?? "Status";
+
+  return {
+    id: status.status_id ?? status.statusid ?? status.id ?? "",
+    name,
+    category,
+    isOpen: Boolean(status.is_open) || category.toLowerCase() === "open" || name.toLowerCase() === "open",
+  };
+}
+
+export async function listFlowStatuses(flowId: string) {
+  const response = await api.get<StatusListDto | StatusDto[]>(`/flows/${encodeURIComponent(flowId)}/statuses/`);
+  const statuses = Array.isArray(response.data) ? response.data : response.data.results ?? [];
+  return statuses.map(normalizeStatus).filter((status) => status.id);
+}
+
+export async function createRequest(payload: CreateRequestPayload) {
+  const response = await api.post<CreateRequestDto>("/requests/", payload);
+  return normalizeCreatedRequest(response.data);
+}

--- a/src/api/requestDetail.ts
+++ b/src/api/requestDetail.ts
@@ -6,6 +6,7 @@ export type RequestDetail = {
   title: string;
   description: string;
   status: string;
+  statusCategory?: string;
   priority: string;
   assignee: string;
   requester: string;
@@ -41,6 +42,27 @@ type AttachmentDto = {
   download_url?: string;
 };
 
+type FlowDto = {
+  flow_id?: string;
+  name?: string;
+  description?: string;
+};
+
+type StatusDto = {
+  status_id?: string;
+  name?: string;
+  category?: string;
+  is_terminal?: boolean;
+};
+
+type UserDto = {
+  user_id?: string;
+  email?: string;
+  display_name?: string;
+  employee_code?: string;
+  avatar_url?: string;
+};
+
 type RequestDetailDto = {
   requestid?: string;
   humanid?: string;
@@ -48,14 +70,14 @@ type RequestDetailDto = {
   human_id?: string;
   title?: string;
   description?: string;
-  status?: string;
+  status?: string | StatusDto | null;
   statusid?: string;
   priority?: string;
-  assignee?: string | null;
+  assignee?: string | UserDto | null;
   assignee_name?: string | null;
-  requester?: string | null;
+  requester?: string | UserDto | null;
   requester_name?: string | null;
-  flow?: string;
+  flow?: string | FlowDto | null;
   flow_name?: string;
   due_at?: string;
   created_at?: string;
@@ -89,16 +111,37 @@ function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachmen
   };
 }
 
+function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
+  if (typeof flow === "string") return flow;
+  return flow?.name ?? fallback ?? "-";
+}
+
+function displayStatus(status?: string | StatusDto | null, fallback?: string) {
+  if (typeof status === "string") return status;
+  return status?.name ?? fallback ?? "-";
+}
+
+function statusCategory(status?: string | StatusDto | null) {
+  if (!status || typeof status === "string") return undefined;
+  return status.category;
+}
+
+function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
+  if (typeof user === "string") return user;
+  return user?.display_name ?? user?.email ?? fallback ?? empty;
+}
+
 function normalizeDetail(detail: RequestDetailDto): RequestDetail {
   return {
-    id: detail.human_id ?? detail.humanid ?? detail.request_id ?? detail.requestid ?? "-",
+    id: detail.request_id ?? detail.human_id ?? detail.humanid ?? detail.requestid ?? "-",
     title: detail.title ?? "Untitled request",
     description: detail.description ?? "",
-    status: detail.status ?? detail.statusid ?? "-",
+    status: displayStatus(detail.status, detail.statusid),
+    statusCategory: statusCategory(detail.status),
     priority: detail.priority ?? "-",
-    assignee: detail.assignee_name ?? detail.assignee ?? "-",
-    requester: detail.requester_name ?? detail.requester ?? "-",
-    flow: detail.flow_name ?? detail.flow ?? "-",
+    assignee: displayUser(detail.assignee, detail.assignee_name, "Unassigned"),
+    requester: displayUser(detail.requester, detail.requester_name),
+    flow: displayFlow(detail.flow, detail.flow_name),
     dueAt: detail.due_at,
     createdAt: detail.created_at ?? "",
     updatedAt: detail.updated_at ?? "",
@@ -131,11 +174,13 @@ export async function getRequestActivity(requestId: string): Promise<RequestActi
 }
 
 export async function getRequestDetailBundle(requestId: string): Promise<RequestDetailBundle> {
-  const [detail, comments, activity] = await Promise.all([
-    getRequestDetail(requestId),
+  const detail = await getRequestDetail(requestId);
+  const [commentsResult, activityResult] = await Promise.allSettled([
     listRequestComments(requestId),
     getRequestActivity(requestId),
   ]);
+  const comments = commentsResult.status === "fulfilled" ? commentsResult.value : [];
+  const activity = activityResult.status === "fulfilled" ? activityResult.value : [];
 
   return { detail, comments, activity };
 }

--- a/src/components/requests/RequestTable.tsx
+++ b/src/components/requests/RequestTable.tsx
@@ -35,13 +35,16 @@ export function RequestTable({
           <button
             key={request.id}
             type="button"
-            onClick={() => onOpenRequest(request.id)}
-            className="grid min-h-12 w-full grid-cols-[120px_1fr_100px_100px_132px_132px_110px] items-center px-4 text-left text-sm hover:bg-primary-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+            onClick={() => {
+              if (request.requestId) onOpenRequest(request.requestId);
+            }}
+            disabled={!request.requestId}
+            className="grid min-h-12 w-full grid-cols-[120px_1fr_100px_100px_132px_132px_110px] items-center px-4 text-left text-sm hover:bg-primary-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <div className="font-semibold text-neutral-800">{request.id}</div>
             <div className="truncate pr-4 text-neutral-900">{request.title}</div>
             <div>
-              <StatusBadge status={request.status} />
+              <StatusBadge status={request.status} category={request.statusCategory} />
             </div>
             <div>
               <PriorityChip priority={request.priority} />

--- a/src/components/requests/StatusBadge.tsx
+++ b/src/components/requests/StatusBadge.tsx
@@ -1,8 +1,10 @@
-export function StatusBadge({ status }: { status: string }) {
-  const normalized = status.toLowerCase();
+export function StatusBadge({ status, category }: { status: string; category?: string }) {
+  const normalized = (category ?? status).toLowerCase();
   const className = normalized.includes("waiting")
     ? "bg-warning-500/15 text-neutral-900"
     : normalized.includes("closed")
+      ? "bg-neutral-200 text-neutral-700"
+      : normalized.includes("terminal")
       ? "bg-neutral-200 text-neutral-700"
       : "bg-primary-50 text-primary-700";
 

--- a/src/features/requestSearch.ts
+++ b/src/features/requestSearch.ts
@@ -17,8 +17,10 @@ export type RequestSearchFilters = {
 
 export type RequestSearchResult = {
   id: string;
+  requestId: string;
   title: string;
   status: string;
+  statusCategory?: string;
   assignee: string;
   flow: string;
   tags: string[];
@@ -34,12 +36,14 @@ export type RequestSearchResponse = {
 type SearchResultDto = {
   requestid?: string;
   humanid?: string;
+  request_id?: string;
+  human_id?: string;
   title?: string;
   statusid?: string;
-  status?: string;
-  assignee?: string | null;
+  status?: string | StatusDto | null;
+  assignee?: string | UserDto | null;
   assignee_name?: string | null;
-  flow?: string;
+  flow?: string | FlowDto | null;
   flow_name?: string;
   tags?: string[];
   updated_at?: string;
@@ -52,13 +56,57 @@ type SearchResponseDto = {
   count?: number;
 };
 
+type FlowDto = {
+  flow_id?: string;
+  name?: string;
+  description?: string;
+};
+
+type StatusDto = {
+  status_id?: string;
+  name?: string;
+  category?: string;
+  is_terminal?: boolean;
+};
+
+type UserDto = {
+  user_id?: string;
+  email?: string;
+  display_name?: string;
+  employee_code?: string;
+  avatar_url?: string;
+};
+
+function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
+  if (typeof flow === "string") return flow;
+  return flow?.name ?? fallback ?? "-";
+}
+
+function displayStatus(status?: string | StatusDto | null, fallback?: string) {
+  if (typeof status === "string") return status;
+  return status?.name ?? fallback ?? "-";
+}
+
+function statusCategory(status?: string | StatusDto | null) {
+  if (!status || typeof status === "string") return undefined;
+  return status.category;
+}
+
+function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
+  if (typeof user === "string") return user;
+  return user?.display_name ?? user?.email ?? fallback ?? empty;
+}
+
 function normalizeSearchResult(result: SearchResultDto): RequestSearchResult {
+  const requestId = result.request_id ?? "";
   return {
-    id: result.humanid ?? result.requestid ?? "-",
+    id: (result.human_id ?? result.humanid ?? requestId) || result.requestid || "-",
+    requestId,
     title: result.title ?? "Untitled request",
-    status: result.status ?? result.statusid ?? "-",
-    assignee: result.assignee_name ?? result.assignee ?? "-",
-    flow: result.flow_name ?? result.flow ?? "-",
+    status: displayStatus(result.status, result.statusid),
+    statusCategory: statusCategory(result.status),
+    assignee: displayUser(result.assignee, result.assignee_name, "Unassigned"),
+    flow: displayFlow(result.flow, result.flow_name),
     tags: result.tags ?? [],
     updatedAt: result.updated_at ?? "",
     snippet: result.snippet ?? result.highlight ?? "",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from "./auth/useAuth";
 import "./index.css";
 import App from "./pages/App";
 import Login from "./pages/Login";
+import RequestCreatePage from "./pages/RequestCreatePage";
 import RequestDetailPage from "./pages/RequestDetailPage";
 
 function Protected({ children }: { children: React.ReactNode }) {
@@ -25,6 +26,14 @@ const router = createBrowserRouter([
     element: (
       <Protected>
         <App initialView="search" />
+      </Protected>
+    ),
+  },
+  {
+    path: "/requests/new",
+    element: (
+      <Protected>
+        <RequestCreatePage />
       </Protected>
     ),
   },

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -38,6 +38,7 @@ const EMPTY_SEARCH_FILTERS: RequestSearchFilters = {
 const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   {
     id: "RT-2025-001001",
+    requestId: "RT-2025-001001",
     title: "VPN not connecting",
     status: "Open",
     assignee: "Ana Gomez",
@@ -48,6 +49,7 @@ const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   },
   {
     id: "RT-2025-001002",
+    requestId: "RT-2025-001002",
     title: "Email quota exceeded",
     status: "In Progress",
     assignee: "Luis Perez",
@@ -58,6 +60,7 @@ const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   },
   {
     id: "RT-2025-001003",
+    requestId: "RT-2025-001003",
     title: "Printer F3 queue stuck",
     status: "Waiting",
     assignee: "-",
@@ -68,6 +71,7 @@ const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   },
   {
     id: "RT-2025-001004",
+    requestId: "RT-2025-001004",
     title: "VPN split tunneling",
     status: "Closed",
     assignee: "Ana Gomez",
@@ -78,6 +82,7 @@ const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   },
   {
     id: "RT-2025-001005",
+    requestId: "RT-2025-001005",
     title: "New hire access package",
     status: "Open",
     assignee: "Marta Ruiz",
@@ -148,7 +153,15 @@ function TopBar({ tenant, onNew, onLogout }: { tenant?: string | null; onNew(): 
   );
 }
 
-function SideNav({ activeView, onNavigate }: { activeView: AppView; onNavigate(view: AppView): void }) {
+function SideNav({
+  activeView,
+  onNavigate,
+  onNewRequest,
+}: {
+  activeView: AppView;
+  onNavigate(view: AppView): void;
+  onNewRequest(): void;
+}) {
   return (
     <aside className="w-60 border-r border-neutral-200 bg-neutral-50 p-3">
       {NAV_ITEMS.map((item) => {
@@ -160,6 +173,7 @@ function SideNav({ activeView, onNavigate }: { activeView: AppView; onNavigate(v
             key={item.id}
             type="button"
             onClick={() => {
+              if (item.id === "new") onNewRequest();
               if (targetView) onNavigate(targetView);
             }}
             className={`mb-1 w-full px-4 py-2 text-left text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600 ${
@@ -184,8 +198,8 @@ function formatDate(value: string) {
   });
 }
 
-function statusClass(status: string) {
-  const normalized = status.toLowerCase();
+function statusClass(status: string, category?: string) {
+  const normalized = (category ?? status).toLowerCase();
   if (normalized.includes("waiting")) return "bg-warning-500/15 text-neutral-900";
   if (normalized.includes("closed")) return "bg-neutral-200 text-neutral-700";
   return "bg-primary-50 text-primary-700";
@@ -258,8 +272,11 @@ function SearchResultsTable({
           <button
             key={result.id}
             type="button"
-            onClick={() => onOpenRequest(result.id)}
-            className="grid min-h-12 grid-cols-[130px_1fr_112px_132px_130px_116px] items-center border-b border-neutral-100 px-4 py-2 text-left text-sm last:border-b-0 hover:bg-primary-50"
+            onClick={() => {
+              if (result.requestId) onOpenRequest(result.requestId);
+            }}
+            disabled={!result.requestId}
+            className="grid min-h-12 grid-cols-[130px_1fr_112px_132px_130px_116px] items-center border-b border-neutral-100 px-4 py-2 text-left text-sm last:border-b-0 hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <div className="font-semibold text-neutral-800">{result.id}</div>
             <div className="min-w-0 pr-4">
@@ -276,7 +293,7 @@ function SearchResultsTable({
               )}
             </div>
             <div>
-              <span className={`rounded px-2 py-1 text-xs font-semibold ${statusClass(result.status)}`}>
+              <span className={`rounded px-2 py-1 text-xs font-semibold ${statusClass(result.status, result.statusCategory)}`}>
                 {result.status}
               </span>
             </div>
@@ -502,17 +519,18 @@ function SearchView() {
 
 export default function App({ initialView = "home" }: { initialView?: AppView }) {
   const { tenant, logout } = useAuth();
+  const navigate = useNavigate();
   const [activeView, setActiveView] = useState<AppView>(initialView);
 
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50">
       <TopBar
         tenant={tenant}
-        onNew={() => alert("New Request is coming in the next step.")}
+        onNew={() => navigate("/requests/new")}
         onLogout={logout}
       />
       <div className="flex flex-1">
-        <SideNav activeView={activeView} onNavigate={setActiveView} />
+        <SideNav activeView={activeView} onNavigate={setActiveView} onNewRequest={() => navigate("/requests/new")} />
         <main className="flex-1 space-y-4 p-6">{activeView === "search" ? <SearchView /> : <HomePage />}</main>
       </div>
     </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -60,6 +60,7 @@ const FALLBACK_SUMMARY: DashboardSummary = {
 const FALLBACK_REQUESTS: DashboardRequest[] = [
   {
     id: "RT-2025-001001",
+    requestId: "RT-2025-001001",
     title: "VPN not connecting",
     status: "Open",
     priority: "High",
@@ -69,6 +70,7 @@ const FALLBACK_REQUESTS: DashboardRequest[] = [
   },
   {
     id: "RT-2025-001002",
+    requestId: "RT-2025-001002",
     title: "Email quota exceeded",
     status: "In Progress",
     priority: "Normal",
@@ -78,6 +80,7 @@ const FALLBACK_REQUESTS: DashboardRequest[] = [
   },
   {
     id: "RT-2025-001003",
+    requestId: "RT-2025-001003",
     title: "Printer F3 queue stuck",
     status: "Waiting",
     priority: "Low",
@@ -87,6 +90,7 @@ const FALLBACK_REQUESTS: DashboardRequest[] = [
   },
   {
     id: "RT-2025-001004",
+    requestId: "RT-2025-001004",
     title: "VPN split tunneling",
     status: "Closed",
     priority: "Normal",
@@ -199,7 +203,7 @@ export function HomePage() {
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => alert("New Request is coming in the next step.")}
+            onClick={() => navigate("/requests/new")}
             className="btn btn-primary"
           >
             New Request

--- a/src/pages/RequestCreatePage.tsx
+++ b/src/pages/RequestCreatePage.tsx
@@ -1,0 +1,426 @@
+import { FocusEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import { AxiosError } from "axios";
+import { useNavigate } from "react-router-dom";
+import { createRequest, CreateRequestPayload, FlowStatus, listFlowStatuses } from "../api/requestCreate";
+
+type FormValues = {
+  title: string;
+  description: string;
+  flow_id: string;
+  status_id: string;
+  priority: string;
+  assignee_id: string;
+  requester_id: string;
+  tags: string;
+  due_at: string;
+};
+
+type FieldErrors = Partial<Record<keyof FormValues, string>>;
+
+type ApiErrorDetail = {
+  field?: keyof FormValues | string;
+  message?: string;
+};
+
+type ApiErrorBody = {
+  code?: string;
+  message?: string;
+  details?: ApiErrorDetail[];
+};
+
+const INITIAL_VALUES: FormValues = {
+  title: "",
+  description: "",
+  flow_id: "",
+  status_id: "",
+  priority: "normal",
+  assignee_id: "",
+  requester_id: "",
+  tags: "",
+  due_at: "",
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  title: "Title",
+  description: "Description",
+  flow_id: "Flow",
+  status_id: "Open status",
+  requester_id: "Requester",
+  assignee_id: "Assignee",
+  due_at: "Due date",
+  priority: "Priority",
+  tags: "Tags",
+};
+
+function validate(values: FormValues) {
+  const errors: FieldErrors = {};
+  if (!values.title.trim()) errors.title = "Title is required.";
+  if (!values.description.trim()) errors.description = "Description is required.";
+  if (!values.flow_id.trim()) errors.flow_id = "Flow is required.";
+  if (!values.status_id.trim()) errors.status_id = "Select a flow with an Open status before submitting.";
+  if (!values.requester_id.trim()) errors.requester_id = "Requester is required.";
+  return errors;
+}
+
+function toPayload(values: FormValues): CreateRequestPayload {
+  const tags = values.tags
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+  return {
+    title: values.title.trim(),
+    description: values.description.trim(),
+    flow_id: values.flow_id.trim(),
+    status_id: values.status_id.trim(),
+    priority: values.priority || undefined,
+    requester_id: values.requester_id.trim(),
+    assignee_id: values.assignee_id.trim() || null,
+    tags,
+    due_at: values.due_at || undefined,
+  };
+}
+
+function detailMessage(detail: ApiErrorDetail) {
+  const field = detail.field ? FIELD_LABELS[detail.field] ?? detail.field : null;
+  const message = detail.message ?? "Invalid value.";
+  return field ? `${field}: ${message}` : message;
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <div className="mt-1 text-sm font-semibold text-danger-500">{message}</div>;
+}
+
+function TextInput({
+  id,
+  label,
+  value,
+  onChange,
+  onBlur,
+  error,
+  helper,
+  required,
+  type = "text",
+}: {
+  id: keyof FormValues;
+  label: string;
+  value: string;
+  onChange(value: string): void;
+  onBlur(event: FocusEvent<HTMLInputElement>): void;
+  error?: string;
+  helper?: string;
+  required?: boolean;
+  type?: string;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor={id}>
+        {label}
+        {required && <span className="text-danger-500"> *</span>}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? `${id}-error` : helper ? `${id}-helper` : undefined}
+        className="h-10 w-full rounded-lg border border-neutral-300 px-3 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50"
+      />
+      {helper && !error && (
+        <div id={`${id}-helper`} className="mt-1 text-xs text-neutral-600">
+          {helper}
+        </div>
+      )}
+      {error && (
+        <div id={`${id}-error`}>
+          <FieldError message={error} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RequestCreatePage() {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<FormValues>(INITIAL_VALUES);
+  const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
+  const [submitted, setSubmitted] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formDetails, setFormDetails] = useState<string[]>([]);
+  const [statuses, setStatuses] = useState<FlowStatus[]>([]);
+  const [statusesLoading, setStatusesLoading] = useState(false);
+  const [statusesError, setStatusesError] = useState<string | null>(null);
+  const [posting, setPosting] = useState(false);
+
+  const validationErrors = useMemo(() => validate(values), [values]);
+  const openStatus = statuses.find((status) => status.isOpen);
+
+  useEffect(() => {
+    let cancelled = false;
+    const flowId = values.flow_id.trim();
+
+    if (!flowId) {
+      setStatuses([]);
+      setStatusesError(null);
+      setValue("status_id", "");
+      return;
+    }
+
+    async function loadStatuses() {
+      setStatusesLoading(true);
+      setStatusesError(null);
+      try {
+        const nextStatuses = await listFlowStatuses(flowId);
+        if (cancelled) return;
+        setStatuses(nextStatuses);
+        const nextOpenStatus = nextStatuses.find((status) => status.isOpen);
+        setValue("status_id", nextOpenStatus?.id ?? "");
+        if (!nextOpenStatus) {
+          setStatusesError("This flow did not return an Open status.");
+        }
+      } catch {
+        if (cancelled) return;
+        setStatuses([]);
+        setValue("status_id", "");
+        setStatusesError("Could not load statuses for this flow.");
+      } finally {
+        if (!cancelled) setStatusesLoading(false);
+      }
+    }
+
+    loadStatuses();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [values.flow_id]);
+
+  function shownError(field: keyof FormValues) {
+    return fieldErrors[field] ?? ((submitted || touched[field]) ? validationErrors[field] : undefined);
+  }
+
+  function setValue(field: keyof FormValues, value: string) {
+    setValues((current) => ({ ...current, [field]: value }));
+    setFormDetails([]);
+    setFieldErrors((current) => {
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
+
+  function markTouched(event: FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
+    const field = event.currentTarget.id as keyof FormValues;
+    setTouched((current) => ({ ...current, [field]: true }));
+  }
+
+  function applyApiErrors(error: AxiosError<ApiErrorBody>) {
+    const response = error.response?.data;
+    const nextFieldErrors: FieldErrors = {};
+
+    response?.details?.forEach((detail) => {
+      if (detail.field && detail.field in values && detail.message) {
+        nextFieldErrors[detail.field as keyof FormValues] = detail.message;
+      }
+    });
+
+    setFieldErrors(nextFieldErrors);
+    setFormDetails(response?.details?.map(detailMessage) ?? []);
+    setFormError(response?.message ?? "Could not create the request. Please review the form and try again.");
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitted(true);
+    setFormError(null);
+    setFormDetails([]);
+    setFieldErrors({});
+
+    if (Object.keys(validationErrors).length > 0) return;
+
+    setPosting(true);
+    try {
+      const created = await createRequest(toPayload(values));
+      if (!created.requestId) {
+        setFormError("The request was created, but the API did not return request_id for detail navigation.");
+        return;
+      }
+      navigate(`/requests/${encodeURIComponent(created.requestId)}`);
+    } catch (requestError) {
+      applyApiErrors(requestError as AxiosError<ApiErrorBody>);
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-b border-neutral-200 bg-white px-6 py-4">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="mb-3 rounded-lg border border-neutral-300 px-3 py-2 text-sm font-semibold text-neutral-700 hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+        >
+          Back
+        </button>
+        <h1 className="text-2xl font-semibold text-neutral-900">New Request</h1>
+        <p className="mt-1 text-sm text-neutral-600">Create a request for intake, assignment, and follow-up.</p>
+      </header>
+
+      <main className="mx-auto max-w-5xl p-6">
+        <form onSubmit={handleSubmit} className="card space-y-5 p-5">
+          {formError && (
+            <div className="rounded-lg border border-danger-500 bg-white px-4 py-3 text-sm font-semibold text-danger-500">
+              {formError}
+              {formDetails.length > 0 && (
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+                  {formDetails.map((detail) => (
+                    <li key={detail}>{detail}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          <TextInput
+            id="title"
+            label="Title"
+            value={values.title}
+            onChange={(value) => setValue("title", value)}
+            onBlur={markTouched}
+            error={shownError("title")}
+            helper="Use a short, searchable request title."
+            required
+          />
+
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="description">
+              Description <span className="text-danger-500">*</span>
+            </label>
+            <textarea
+              id="description"
+              value={values.description}
+              onChange={(event) => setValue("description", event.target.value)}
+              onBlur={markTouched}
+              aria-invalid={Boolean(shownError("description"))}
+              aria-describedby={shownError("description") ? "description-error" : "description-helper"}
+              className="min-h-32 w-full resize-y rounded-lg border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50"
+            />
+            {!shownError("description") && (
+              <div id="description-helper" className="mt-1 text-xs text-neutral-600">
+                Include context, impact, and what outcome is needed.
+              </div>
+            )}
+            {shownError("description") && (
+              <div id="description-error">
+                <FieldError message={shownError("description")} />
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <TextInput
+              id="flow_id"
+              label="Flow ID"
+              value={values.flow_id}
+              onChange={(value) => setValue("flow_id", value)}
+              onBlur={markTouched}
+              error={shownError("flow_id")}
+              helper="Paste the Flow ID. The Open status is loaded from this flow."
+              required
+            />
+
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="priority">
+                Priority
+              </label>
+              <select
+                id="priority"
+                value={values.priority}
+                onChange={(event) => setValue("priority", event.target.value)}
+                onBlur={markTouched}
+                className="h-10 w-full rounded-lg border border-neutral-300 px-3 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50"
+              >
+                <option value="low">Low</option>
+                <option value="normal">Normal</option>
+                <option value="high">High</option>
+                <option value="urgent">Urgent</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700">
+            <div className="font-semibold text-neutral-800">Open status</div>
+            {statusesLoading && <div className="mt-1 text-neutral-600">Loading statuses for selected flow...</div>}
+            {!statusesLoading && openStatus && (
+              <div className="mt-1">
+                {openStatus.name} <span className="text-neutral-600">({openStatus.id})</span>
+              </div>
+            )}
+            {!statusesLoading && !openStatus && (
+              <div className="mt-1 text-danger-500">{statusesError ?? shownError("status_id")}</div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <TextInput
+              id="requester_id"
+              label="Requester ID"
+              value={values.requester_id}
+              onChange={(value) => setValue("requester_id", value)}
+              onBlur={markTouched}
+              error={shownError("requester_id")}
+              helper="Paste the requester user ID."
+              required
+            />
+            <TextInput
+              id="assignee_id"
+              label="Assignee ID"
+              value={values.assignee_id}
+              onChange={(value) => setValue("assignee_id", value)}
+              onBlur={markTouched}
+              helper="Leave blank to send assignee_id as null."
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <TextInput
+              id="tags"
+              label="Tags"
+              value={values.tags}
+              onChange={(value) => setValue("tags", value)}
+              onBlur={markTouched}
+              helper="Separate tags with commas."
+            />
+            <TextInput
+              id="due_at"
+              label="Due date"
+              type="date"
+              value={values.due_at}
+              onChange={(value) => setValue("due_at", value)}
+              onBlur={markTouched}
+            />
+          </div>
+
+          <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-4">
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="rounded-lg border border-neutral-300 px-4 py-2 text-sm font-semibold text-neutral-700 hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+              disabled={posting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={posting}>
+              {posting ? "Creating" : "Create Request"}
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/RequestDetailPage.tsx
+++ b/src/pages/RequestDetailPage.tsx
@@ -55,6 +55,8 @@ const FALLBACK_ACTIVITY: RequestActivityEvent[] = [
   },
 ];
 
+const ENABLE_DEMO_DETAIL_FALLBACK = import.meta.env.VITE_ENABLE_DEMO_DETAIL_FALLBACK === "true";
+
 function formatDate(value?: string) {
   if (!value || Number.isNaN(Date.parse(value))) return "-";
   return new Date(value).toLocaleString(undefined, {
@@ -179,6 +181,7 @@ export default function RequestDetailPage() {
   const [activity, setActivity] = useState<RequestActivityEvent[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -195,10 +198,17 @@ export default function RequestDetailPage() {
         setError(null);
       } catch {
         if (cancelled) return;
-        setDetail({ ...FALLBACK_DETAIL, id: requestId });
-        setComments(FALLBACK_COMMENTS);
-        setActivity(FALLBACK_ACTIVITY);
-        setError("Could not load request detail from API. Showing local demo data.");
+        if (ENABLE_DEMO_DETAIL_FALLBACK) {
+          setDetail({ ...FALLBACK_DETAIL, id: requestId });
+          setComments(FALLBACK_COMMENTS);
+          setActivity(FALLBACK_ACTIVITY);
+          setError("Could not load request detail from API. Showing local demo data.");
+          return;
+        }
+        setDetail(null);
+        setComments([]);
+        setActivity([]);
+        setError("Could not load request detail from API. Please confirm the request exists and try again.");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -209,14 +219,19 @@ export default function RequestDetailPage() {
     return () => {
       cancelled = true;
     };
-  }, [requestId]);
+  }, [requestId, loadAttempt]);
 
   if (!detail && loading) {
     return <div className="p-6 text-sm text-neutral-500">Loading request detail...</div>;
   }
 
   if (!detail) {
-    return <ErrorState message="Request detail is unavailable." onRetry={() => navigate("/")} />;
+    return (
+      <ErrorState
+        message={error ?? "Request detail is unavailable."}
+        onRetry={() => setLoadAttempt((current) => current + 1)}
+      />
+    );
   }
 
   return (
@@ -235,7 +250,7 @@ export default function RequestDetailPage() {
             <h1 className="mt-1 text-2xl font-semibold text-neutral-900">{detail.title}</h1>
           </div>
           <div className="flex items-center gap-2">
-            <StatusBadge status={detail.status} />
+            <StatusBadge status={detail.status} category={detail.statusCategory} />
             <PriorityChip priority={detail.priority} />
           </div>
         </div>


### PR DESCRIPTION
Adds the protected /requests/new create flow, backend-aligned create payload mapping, request_id-based post-create navigation, nested Request Detail normalization, and Home/Search request_id row routing. Uses the shared API client for auth and tenant headers. Updates the Sprint 2 ExecPlan. Validation run: tsc --noEmit, eslint, and vite build passed via local node_modules binaries; pnpm commands could not run because pnpm is not installed on PATH.