### PR TITLE
feat(requests): add workflow transitions

### DIFF
--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -71,6 +71,28 @@ Implementation steps:
 
 Fetch available transitions, render actions, support optional transition comment, and refresh detail after success.
 
+Implementation steps:
+
+1. Extend `src/api/requestDetail.ts`:
+   - Export `RequestTransition`, `listRequestTransitions(requestId)`, and `applyRequestTransition(requestId, payload)`.
+   - Use the shared `src/lib/api.ts` Axios instance so `Authorization` and `X-Tenant` headers are included automatically.
+   - Fetch available workflow actions from `GET /requests/{request_id}/available-transitions/`.
+   - Apply the selected action with `POST /requests/{request_id}/transition/` using `transition_id` and optional `comment_markdown`.
+   - Normalize transition IDs, labels, destination status names/categories, terminal flags, and comment requirements.
+   - Never update workflow state by PATCHing the request detail endpoint; transition validation, status updates, optional comments, and activity events are handled by the workflow transition endpoint.
+2. Update `src/pages/RequestDetailPage.tsx`:
+   - Load transitions after real detail loads.
+   - Render compact workflow actions in the right sidebar.
+   - Support an optional transition comment and required-comment validation when the API marks a transition as requiring one.
+   - Always ask the API for available transitions, even when the current status is terminal, so backend-allowed actions such as Reopen can be shown.
+   - Refresh detail, transitions, comments, and activity after a successful transition.
+   - Mirror a submitted transition comment into the regular request comments flow when the transition response does not attach one, then include comments in the Activity timeline display.
+   - Show a clear error state on transition list or apply failures.
+3. Keep out of scope:
+   - Workflow builder/admin screens.
+   - Custom transition forms beyond one optional comment.
+   - Backend workflow changes.
+
 ### Milestone 4: Dashboard summary integration
 
 Replace multiple count calls with `GET /api/dashboard/summary/` when available.
@@ -100,6 +122,23 @@ Milestone 2 exact manual verification:
 13. Return Home and confirm the Home page `New Request` button also navigates to `/requests/new`.
 14. If the API returns validation errors, confirm they render inline or in a form-level error without navigating.
 
+Milestone 3 exact manual verification:
+
+1. Open an existing non-terminal request detail page at `/requests/{request_id}`.
+2. Confirm `GET /api/requests/{request_id}/available-transitions/` runs with `Authorization` and `X-Tenant` headers.
+3. Confirm available workflow actions render in the right sidebar.
+4. Select a non-terminal workflow action, optionally add a comment, and submit.
+5. Confirm `POST /api/requests/{request_id}/transition/` sends `transition_id` and optional `comment_markdown`.
+6. Confirm no `PATCH /api/requests/{request_id}/` is sent for workflow actions.
+7. Select a terminal/close transition when available and submit.
+8. Confirm close can include a comment in the transition `comment_markdown` payload.
+9. Confirm the detail page refreshes and shows the new status.
+10. Confirm the activity timeline records `status.changed` or `request.closed`.
+11. Confirm the request refreshes into the closed/terminal status and the workflow panel still loads available transitions.
+12. If the backend allows reopening, confirm a Reopen action appears on the closed request and can move the request back to an open status.
+13. Confirm an optional transition comment appears in the Comments section and the Activity timeline after refresh.
+14. Force or observe an API failure and confirm a clear inline error appears without navigating away.
+
 ## Acceptance criteria
 
 Request Detail exists; Create Request works; transition/close works; dashboard summary is consumed; profile/preferences exists; states are implemented; UI follows tokens; auth and X-Tenant headers are sent.
@@ -117,11 +156,24 @@ Milestone 2 acceptance criteria:
 - Home and Search rows navigate with `request.request_id`; rows without `request_id` do not navigate to `/requests/-`.
 - No attachment upload, transition, or close behavior is introduced in this milestone.
 
+Milestone 3 acceptance criteria:
+
+- Request Detail fetches available transitions for the current `request_id` through the shared Axios client.
+- The right sidebar renders transition actions without reintroducing placeholder alerts or old demo-only UI.
+- A selected transition can be submitted with optional comment text.
+- Required transition comments are validated client-side when the transition contract says they are required.
+- Successful transitions refresh the detail, comments, activity, and available actions.
+- Terminal/closed requests still fetch available transitions and show Reopen when the API allows it.
+- Transition load/apply failures show clear errors and keep the user on Request Detail.
+- Workflow actions call `POST /requests/{request_id}/transition/`; they never call `PATCH /requests/{request_id}/`.
+- Close actions can include a comment.
+- Activity is refreshed after transition so `status.changed`, `request.closed`, and user transition comments appear in the timeline.
+
 ## Progress
 
 - [x] Milestone 1 completed.
 - [x] Milestone 2 completed.
-- [ ] Milestone 3 completed.
+- [x] Milestone 3 completed.
 - [ ] Milestone 4 completed.
 - [ ] Milestone 5 completed.
 
@@ -140,6 +192,13 @@ Milestone 2 acceptance criteria:
 - 2026-05-30: Request Detail should treat the detail API response as authoritative. Comment or activity fetch failures can show empty sections, but a `200` detail response should still render real request data.
 - 2026-05-30: Detail responses now include nested `flow`, `status`, `requester`, and nullable `assignee` objects. Rendering those fields directly crashes React, so adapters must flatten them to display strings before JSX.
 - 2026-05-30: Home/Search list rows need a distinct `requestId` route key from the display `id`; using `id`, `human_id`, or `-` can route users to `/requests/-` or the wrong detail URL.
+- 2026-05-31: This web repo does not include an OpenAPI document; workflow UI follows the existing request subresource pattern already used by comments, attachments, and activity.
+- 2026-05-31: Request detail statuses include `is_terminal`; the frontend can use that flag to suppress further workflow actions after close.
+- 2026-06-06: Real Day 6 testing showed the status-derived PATCH fallback was wrong. The backend rejects `PATCH /requests/{request_id}/` with tenant validation such as `flow_id: Not found for this tenant`; workflow actions must use the workflow transition endpoint.
+- 2026-06-06: The API exposes `GET /requests/{request_id}/available-transitions/` for allowed actions and `POST /requests/{request_id}/transition/` for applying one selected `transition_id`.
+- 2026-06-06: Transition comments are sent as `comment_markdown`, not `comment`, and activity/status updates are backend workflow responsibilities.
+- 2026-06-06: Closed requests can still have backend-allowed available transitions such as Reopen, so the web must not suppress workflow loading merely because `status.is_terminal` is true.
+- 2026-06-06: The tested transition response accepted `comment_markdown`, but the activity payload still showed `comment_id: null`; the web needs to preserve the user's transition comment visibly by refreshing/including regular request comments in the timeline.
 
 ## Decision Log
 
@@ -154,7 +213,15 @@ Milestone 2 acceptance criteria:
 - 2026-05-30: Disable the Request Detail demo-data fallback by default. It is now available only when `VITE_ENABLE_DEMO_DETAIL_FALLBACK=true`; authenticated API flows show a clear error state instead.
 - 2026-05-30: Normalize nested request detail/list/search fields at API adapter boundaries. Components receive strings for flow, status, requester, and assignee, plus optional `statusCategory` for badge styling.
 - 2026-05-30: Keep table display IDs separate from route IDs. Home and Search route with `request_id` only and disable row activation when that value is missing.
+- 2026-05-31: Keep transition controls in the Request Detail right sidebar so lifecycle actions stay close to status, priority, assignee, and due-date context.
+- 2026-06-06: Use only the workflow endpoints for lifecycle changes: `GET /available-transitions/` and `POST /transition/`.
+- 2026-06-06: Store and submit the selected `transition_id`; do not derive or submit destination `status_id` from the web UI.
+- 2026-06-06: Surface backend validation messages from transition failures directly in the workflow panel.
+- 2026-06-06: Always fetch available transitions from the API for the current request, including terminal/closed requests, and let an empty API response decide whether no actions are available.
+- 2026-06-06: After a successful transition with comment text, create a regular request comment as a visibility fallback and merge comments into the Activity timeline display.
 
 ## Outcomes & Retrospective
 
 Milestone 2 outcome: `/requests/new` now exists as a protected full-page create flow. Top bar, left rail, and Home `New Request` actions navigate to it. The form validates title, description, flow ID, requester ID, and Open status ID before submission, sends `POST /requests/` through the shared Axios client, renders API/form errors without navigating, disables submit while posting, and navigates to `/requests/{request_id}` only when the API returns the public `request_id`. The payload now uses backend field names (`flow_id`, `status_id`, `requester_id`, `assignee_id`) and lowercase priority values. Request Detail loads real API data through the shared Axios client, normalizes nested detail objects into display strings, and no longer shows demo fallback messaging by default. Home and Search row navigation now use `request_id` instead of display IDs and avoid routing missing IDs to `/requests/-`. Create-time attachments, workflow transitions, and close behavior remain deferred to later milestones.
+
+Milestone 3 outcome: Request Detail now loads allowed workflow actions from `GET /requests/{request_id}/available-transitions/`, renders user-friendly labels based on `to_status.name`, stores the selected `transition_id`, applies it with `POST /requests/{request_id}/transition/` and optional `comment_markdown`, and refreshes detail/comments/activity/actions after success. Workflow actions no longer PATCH the request detail endpoint. Closed/terminal requests still fetch available actions so Reopen can appear when the API allows it. Transition comments are preserved as regular request comments when needed and are merged into the Activity timeline display. Transition load/apply failures show backend validation messages inline without navigating away.

--- a/src/api/requestDetail.ts
+++ b/src/api/requestDetail.ts
@@ -1,5 +1,10 @@
 import api from "../lib/api";
-import { RequestComment, RequestCommentAttachment, listRequestComments } from "../features/requestActivity";
+import {
+  RequestComment,
+  RequestCommentAttachment,
+  createRequestComment,
+  listRequestComments,
+} from "../features/requestActivity";
 
 export type RequestDetail = {
   id: string;
@@ -7,6 +12,7 @@ export type RequestDetail = {
   description: string;
   status: string;
   statusCategory?: string;
+  statusIsTerminal: boolean;
   priority: string;
   assignee: string;
   requester: string;
@@ -29,6 +35,20 @@ export type RequestDetailBundle = {
   detail: RequestDetail;
   comments: RequestComment[];
   activity: RequestActivityEvent[];
+};
+
+export type RequestTransition = {
+  id: string;
+  label: string;
+  toStatus?: string;
+  toStatusCategory?: string;
+  isTerminal: boolean;
+  requiresComment: boolean;
+};
+
+export type ApplyTransitionPayload = {
+  transitionId: string;
+  comment?: string;
 };
 
 type AttachmentDto = {
@@ -100,6 +120,22 @@ type ActivityResponseDto = {
   results?: ActivityDto[];
 };
 
+type TransitionDto = {
+  id?: string;
+  transition_id?: string;
+  name?: string;
+  label?: string;
+  to_status?: string | StatusDto | null;
+  to_status_name?: string;
+  is_terminal?: boolean;
+  requires_comment?: boolean;
+};
+
+type TransitionResponseDto = {
+  results?: TransitionDto[];
+  transitions?: TransitionDto[];
+};
+
 function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
   return {
     id: attachment.id ?? attachment.attachmentid ?? crypto.randomUUID(),
@@ -126,6 +162,10 @@ function statusCategory(status?: string | StatusDto | null) {
   return status.category;
 }
 
+function statusIsTerminal(status?: string | StatusDto | null) {
+  return Boolean(status && typeof status !== "string" && status.is_terminal);
+}
+
 function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
   if (typeof user === "string") return user;
   return user?.display_name ?? user?.email ?? fallback ?? empty;
@@ -138,6 +178,7 @@ function normalizeDetail(detail: RequestDetailDto): RequestDetail {
     description: detail.description ?? "",
     status: displayStatus(detail.status, detail.statusid),
     statusCategory: statusCategory(detail.status),
+    statusIsTerminal: statusIsTerminal(detail.status),
     priority: detail.priority ?? "-",
     assignee: displayUser(detail.assignee, detail.assignee_name, "Unassigned"),
     requester: displayUser(detail.requester, detail.requester_name),
@@ -149,6 +190,22 @@ function normalizeDetail(detail: RequestDetailDto): RequestDetail {
   };
 }
 
+function normalizeTransition(transition: TransitionDto): RequestTransition {
+  const toStatus = displayStatus(transition.to_status, transition.to_status_name);
+  const isTerminal = Boolean(transition.is_terminal) || statusIsTerminal(transition.to_status);
+  return {
+    id: transition.transition_id ?? transition.id ?? "",
+    label:
+      transition.label ??
+      transition.name ??
+      (isTerminal ? "Close Request" : toStatus && toStatus !== "-" ? `Move to ${toStatus}` : "Apply Action"),
+    toStatus,
+    toStatusCategory: statusCategory(transition.to_status),
+    isTerminal,
+    requiresComment: Boolean(transition.requires_comment),
+  };
+}
+
 function normalizeActivity(activity: ActivityDto): RequestActivityEvent {
   return {
     id: activity.id ?? activity.activityid ?? crypto.randomUUID(),
@@ -157,6 +214,28 @@ function normalizeActivity(activity: ActivityDto): RequestActivityEvent {
     createdAt: activity.created_at ?? new Date().toISOString(),
     payload: activity.payload ? JSON.stringify(activity.payload) : undefined,
   };
+}
+
+export async function listRequestTransitions(requestId: string): Promise<RequestTransition[]> {
+  const response = await api.get<TransitionResponseDto | TransitionDto[]>(
+    `/requests/${encodeURIComponent(requestId)}/available-transitions/`,
+  );
+  const transitions = Array.isArray(response.data)
+    ? response.data
+    : response.data.transitions ?? response.data.results ?? [];
+  return transitions.map(normalizeTransition).filter((transition) => transition.id);
+}
+
+export async function applyRequestTransition(requestId: string, payload: ApplyTransitionPayload) {
+  const comment = payload.comment?.trim();
+  await api.post(`/requests/${encodeURIComponent(requestId)}/transition/`, {
+    transition_id: payload.transitionId,
+    comment_markdown: comment || undefined,
+  });
+
+  if (comment) {
+    await createRequestComment(requestId, comment, []);
+  }
 }
 
 export async function getRequestDetail(requestId: string): Promise<RequestDetail> {

--- a/src/pages/RequestDetailPage.tsx
+++ b/src/pages/RequestDetailPage.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
+import { AxiosError } from "axios";
 import { useNavigate, useParams } from "react-router-dom";
-import { RequestActivityEvent, RequestDetail, getRequestDetailBundle } from "../api/requestDetail";
+import {
+  RequestActivityEvent,
+  RequestDetail,
+  RequestTransition,
+  applyRequestTransition,
+  getRequestDetailBundle,
+  listRequestTransitions,
+} from "../api/requestDetail";
 import { EmptyState } from "../components/common/EmptyState";
 import { ErrorState } from "../components/common/ErrorState";
 import { PriorityChip } from "../components/requests/PriorityChip";
@@ -12,6 +20,7 @@ const FALLBACK_DETAIL: RequestDetail = {
   title: "VPN not connecting",
   description: "User cannot connect after password rotation. VPN client reports invalid profile.",
   status: "Open",
+  statusIsTerminal: false,
   priority: "High",
   assignee: "Ana Gomez",
   requester: "Carlos Diaz",
@@ -56,6 +65,38 @@ const FALLBACK_ACTIVITY: RequestActivityEvent[] = [
 ];
 
 const ENABLE_DEMO_DETAIL_FALLBACK = import.meta.env.VITE_ENABLE_DEMO_DETAIL_FALLBACK === "true";
+
+type ApiErrorBody = {
+  code?: string;
+  message?: string;
+  detail?: string;
+  details?: Array<{ field?: string; message?: string }>;
+  [key: string]: unknown;
+};
+
+function formatApiError(error: unknown, fallback: string) {
+  const response = (error as AxiosError<ApiErrorBody>).response?.data;
+  if (!response) return fallback;
+
+  if (response.message) return response.message;
+  if (response.detail) return response.detail;
+  if (Array.isArray(response.details) && response.details.length > 0) {
+    return response.details
+      .map((detail) => (detail.field ? `${detail.field}: ${detail.message ?? "Invalid value."}` : detail.message))
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  const fieldErrors = Object.entries(response)
+    .filter(([key]) => !["code", "message", "detail", "details"].includes(key))
+    .flatMap(([key, value]) => {
+      if (Array.isArray(value)) return value.map((item) => `${key}: ${String(item)}`);
+      if (typeof value === "string") return [`${key}: ${value}`];
+      return [];
+    });
+
+  return fieldErrors.length > 0 ? fieldErrors.join(" ") : fallback;
+}
 
 function formatDate(value?: string) {
   if (!value || Number.isNaN(Date.parse(value))) return "-";
@@ -150,14 +191,32 @@ function AttachmentsSection({ detail, comments }: { detail: RequestDetail; comme
   );
 }
 
-function ActivitySection({ events }: { events: RequestActivityEvent[] }) {
-  if (events.length === 0) {
+function ActivitySection({ events, comments }: { events: RequestActivityEvent[]; comments: RequestComment[] }) {
+  const timelineEvents = useMemo(() => {
+    const commentEvents: RequestActivityEvent[] = comments
+      .filter((comment) => comment.body.trim())
+      .map((comment) => ({
+        id: `comment-${comment.id}`,
+        actorName: comment.authorName,
+        verb: "commented",
+        createdAt: comment.createdAt,
+        payload: comment.body,
+      }));
+
+    return [...events, ...commentEvents].sort((left, right) => {
+      const leftTime = Date.parse(left.createdAt);
+      const rightTime = Date.parse(right.createdAt);
+      return (Number.isNaN(rightTime) ? 0 : rightTime) - (Number.isNaN(leftTime) ? 0 : leftTime);
+    });
+  }, [comments, events]);
+
+  if (timelineEvents.length === 0) {
     return <EmptyState title="No activity yet." body="Request history will appear here." />;
   }
 
   return (
     <div className="space-y-3">
-      {events.map((event) => (
+      {timelineEvents.map((event) => (
         <div key={event.id} className="rounded-lg border border-neutral-200 bg-white p-3">
           <div className="flex items-center justify-between gap-3">
             <div className="text-sm text-neutral-900">
@@ -165,9 +224,95 @@ function ActivitySection({ events }: { events: RequestActivityEvent[] }) {
             </div>
             <time className="text-xs text-neutral-500">{formatDate(event.createdAt)}</time>
           </div>
-          {event.payload && <div className="mt-2 text-xs text-neutral-600">{event.payload}</div>}
+          {event.payload && <div className="mt-2 whitespace-pre-wrap text-xs text-neutral-600">{event.payload}</div>}
         </div>
       ))}
+    </div>
+  );
+}
+
+function TransitionActions({
+  transitions,
+  selectedTransitionId,
+  comment,
+  submitting,
+  loading,
+  error,
+  success,
+  onSelect,
+  onCommentChange,
+  onSubmit,
+  onRetry,
+}: {
+  transitions: RequestTransition[];
+  selectedTransitionId: string;
+  comment: string;
+  submitting: boolean;
+  loading: boolean;
+  error: string | null;
+  success: string | null;
+  onSelect(transitionId: string): void;
+  onCommentChange(comment: string): void;
+  onSubmit(): void;
+  onRetry(): void;
+}) {
+  if (loading) {
+    return <div className="text-sm text-neutral-500">Loading actions...</div>;
+  }
+
+  if (transitions.length === 0) {
+    return <EmptyState title="No actions available." body="Available workflow actions will appear here." />;
+  }
+
+  const selectedTransition = transitions.find((transition) => transition.id === selectedTransitionId);
+
+  return (
+    <div className="space-y-3">
+      {error && <ErrorState message={error} onRetry={onRetry} />}
+      {success && (
+        <div className="rounded-lg border border-primary-600 bg-primary-50 px-3 py-2 text-sm font-semibold text-primary-700">
+          {success}
+        </div>
+      )}
+      <div className="grid gap-2">
+        {transitions.map((transition) => (
+          <button
+            key={transition.id}
+            type="button"
+            onClick={() => onSelect(transition.id)}
+            className={`rounded-lg border px-3 py-2 text-left text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600 ${
+              selectedTransitionId === transition.id
+                ? "border-primary-600 bg-primary-50 text-primary-700"
+                : "border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50"
+            }`}
+          >
+            <span>{transition.label}</span>
+            {transition.toStatus && !transition.label.toLowerCase().includes(transition.toStatus.toLowerCase()) && (
+              <span className="ml-2 text-xs font-medium text-neutral-500">to {transition.toStatus}</span>
+            )}
+          </button>
+        ))}
+      </div>
+      <div>
+        <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="transition-comment">
+          Comment{selectedTransition?.requiresComment ? <span className="text-danger-500"> *</span> : null}
+        </label>
+        <textarea
+          id="transition-comment"
+          value={comment}
+          onChange={(event) => onCommentChange(event.target.value)}
+          className="min-h-24 w-full resize-y rounded-lg border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50"
+          placeholder="Add context for this workflow action."
+        />
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary w-full"
+        onClick={onSubmit}
+        disabled={submitting || !selectedTransitionId}
+      >
+        {submitting ? "Applying" : selectedTransition?.isTerminal ? "Close Request" : "Apply Action"}
+      </button>
     </div>
   );
 }
@@ -182,6 +327,13 @@ export default function RequestDetailPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadAttempt, setLoadAttempt] = useState(0);
+  const [transitions, setTransitions] = useState<RequestTransition[]>([]);
+  const [transitionsLoading, setTransitionsLoading] = useState(false);
+  const [transitionsError, setTransitionsError] = useState<string | null>(null);
+  const [selectedTransitionId, setSelectedTransitionId] = useState("");
+  const [transitionComment, setTransitionComment] = useState("");
+  const [transitionSubmitting, setTransitionSubmitting] = useState(false);
+  const [transitionSuccess, setTransitionSuccess] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -220,6 +372,71 @@ export default function RequestDetailPage() {
       cancelled = true;
     };
   }, [requestId, loadAttempt]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTransitions() {
+      if (!requestId || !detail) {
+        setTransitions([]);
+        setSelectedTransitionId("");
+        setTransitionsError(null);
+        return;
+      }
+
+      setTransitionsLoading(true);
+      try {
+        const nextTransitions = await listRequestTransitions(requestId);
+        if (cancelled) return;
+        setTransitions(nextTransitions);
+        setSelectedTransitionId((current) =>
+          current && nextTransitions.some((transition) => transition.id === current) ? current : nextTransitions[0]?.id ?? "",
+        );
+        setTransitionsError(null);
+      } catch (requestError) {
+        if (cancelled) return;
+        setTransitions([]);
+        setSelectedTransitionId("");
+        setTransitionsError(formatApiError(requestError, "Could not load workflow actions."));
+      } finally {
+        if (!cancelled) setTransitionsLoading(false);
+      }
+    }
+
+    loadTransitions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detail, loadAttempt, requestId]);
+
+  async function submitTransition() {
+    const selectedTransition = transitions.find((transition) => transition.id === selectedTransitionId);
+    if (!requestId || !selectedTransition) return;
+
+    if (selectedTransition.requiresComment && !transitionComment.trim()) {
+      setTransitionsError("A comment is required for this workflow action.");
+      return;
+    }
+
+    setTransitionSubmitting(true);
+    setTransitionsError(null);
+    setTransitionSuccess(null);
+    try {
+      await applyRequestTransition(requestId, {
+        transitionId: selectedTransition.id,
+        comment: transitionComment,
+      });
+      setTransitionComment("");
+      setSelectedTransitionId("");
+      setTransitionSuccess("Workflow action applied.");
+      setLoadAttempt((current) => current + 1);
+    } catch (requestError) {
+      setTransitionsError(formatApiError(requestError, "Could not apply the workflow action. Please try again."));
+    } finally {
+      setTransitionSubmitting(false);
+    }
+  }
 
   if (!detail && loading) {
     return <div className="p-6 text-sm text-neutral-500">Loading request detail...</div>;
@@ -284,12 +501,32 @@ export default function RequestDetailPage() {
           <section className="card p-4">
             <h2 className="text-lg font-semibold text-neutral-900">Activity</h2>
             <div className="mt-3">
-              <ActivitySection events={activity} />
+              <ActivitySection events={activity} comments={comments} />
             </div>
           </section>
         </div>
 
         <aside className="card h-fit space-y-4 p-4">
+          <section className="space-y-3 border-b border-neutral-200 pb-4">
+            <h2 className="text-sm font-semibold uppercase text-neutral-500">Workflow</h2>
+            <TransitionActions
+              transitions={transitions}
+              selectedTransitionId={selectedTransitionId}
+              comment={transitionComment}
+              submitting={transitionSubmitting}
+              loading={transitionsLoading}
+              error={transitionsError}
+              success={transitionSuccess}
+              onSelect={(transitionId) => {
+                setSelectedTransitionId(transitionId);
+                setTransitionsError(null);
+                setTransitionSuccess(null);
+              }}
+              onCommentChange={setTransitionComment}
+              onSubmit={submitTransition}
+              onRetry={() => setLoadAttempt((current) => current + 1)}
+            />
+          </section>
           <DetailField label="Status" value={detail.status} />
           <DetailField label="Priority" value={detail.priority} />
           <DetailField label="Assignee" value={detail.assignee} />


### PR DESCRIPTION
Adds Request Detail workflow actions for Sprint 2 Day 5-6.\n\nSummary:\n- Loads available workflow actions from GET /requests/{request_id}/available-transitions/.\n- Applies selected transitions through POST /requests/{request_id}/transition/ with transition_id and optional comment_markdown.\n- Refreshes detail, comments, activity, and available actions after success.\n- Supports closed-request Reopen actions when the API returns them.\n- Preserves transition comments in the visible comments/activity timeline.\n- Updates the Sprint 2 ExecPlan with discoveries, decisions, and verification steps.\n\nValidation:\n- pnpm lint/build could not run because pnpm is not installed on PATH in this environment.\n- Local TypeScript check passed via node_modules tsc.\n- Local ESLint passed via node_modules eslint.\n- Local Vite production build passed via node_modules vite build.