### PR TITLE
fix(requests): wire assignment user endpoint

### DIFF
--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -206,6 +206,8 @@ Milestone 4 acceptance criteria:
 - [x] Milestone 2 completed.
 - [x] Milestone 3 completed.
 - [x] Milestone 4 completed.
+- [x] Sprint 2 demo assignment sidebar fix completed.
+- [x] Sprint 2 assignment user endpoint/display fix completed.
 - [ ] Milestone 5 completed.
 
 ## Surprises & Discoveries
@@ -232,6 +234,10 @@ Milestone 4 acceptance criteria:
 - 2026-06-06: The tested transition response accepted `comment_markdown`, but the activity payload still showed `comment_id: null`; the web needs to preserve the user's transition comment visibly by refreshing/including regular request comments in the timeline.
 - 2026-06-06: Home KPI loading was still implemented as four `/requests/` count queries. Day 7 replaces that with the dedicated dashboard summary endpoint.
 - 2026-06-06: The web repo has no local OpenAPI file, so the dashboard summary adapter accepts both snake_case and camelCase response names while pointing at the confirmed summary endpoint path.
+- 2026-06-06: Request Detail had display-only assignee text but not the assignee UUID needed to submit assignment changes. The detail adapter now preserves `assignee_id` while still rendering readable assignee names.
+- 2026-06-06: The existing tenant user lookup can feed a compact assignment dropdown; Unassigned must submit `assignee_id: null`, never an empty string.
+- 2026-06-08: The API exposes tenant users at `GET /users/`, not `/users/lookup/`; the assignment dropdown must use `/users/` and normalize either an array response or a paginated `results` response.
+- 2026-06-08: Current Assignee should be derived from `assignee.display_name` or `assignee.email`, with `Unassigned` as the safe fallback, so UUIDs, raw objects, and lookup errors do not appear as assignee text.
 
 ## Decision Log
 
@@ -254,6 +260,8 @@ Milestone 4 acceptance criteria:
 - 2026-06-06: After a successful transition with comment text, create a regular request comment as a visibility fallback and merge comments into the Activity timeline display.
 - 2026-06-06: Use `GET /dashboard/summary/` as the sole KPI source for Home summary cards; keep request list loading unchanged for this milestone.
 - 2026-06-06: Do not fall back to demo KPI values when the authenticated summary endpoint fails; show a clear error while keeping zero or last-known values.
+- 2026-06-06: Keep the assignment demo fix in the Request Detail sidebar and use the normal request partial update with `assignee_id`; this is a narrow lifecycle support control, not the full user profile/preferences milestone.
+- 2026-06-08: Use `GET /users/` for the Request Detail assignment user list and keep lookup failures scoped to a small dropdown error while preserving readable Current Assignee text.
 
 ## Outcomes & Retrospective
 
@@ -262,3 +270,5 @@ Milestone 2 outcome: `/requests/new` now exists as a protected full-page create 
 Milestone 3 outcome: Request Detail now loads allowed workflow actions from `GET /requests/{request_id}/available-transitions/`, renders user-friendly labels based on `to_status.name`, stores the selected `transition_id`, applies it with `POST /requests/{request_id}/transition/` and optional `comment_markdown`, and refreshes detail/comments/activity/actions after success. Workflow actions no longer PATCH the request detail endpoint. Closed/terminal requests still fetch available actions so Reopen can appear when the API allows it. Transition comments are preserved as regular request comments when needed and are merged into the Activity timeline display. Transition load/apply failures show backend validation messages inline without navigating away.
 
 Milestone 4 outcome: Home KPI cards now load from the dedicated `GET /dashboard/summary/` endpoint through the shared Axios client, normalizing summary response fields into Open, In Progress, Due Today, and Overdue values. The old four-call `/requests/` count fan-out was removed, and summary failures now show a clear error instead of demo KPI fallback values.
+
+Sprint 2 demo assignment fix outcome: Request Detail now loads tenant users from `GET /users/`, shows a compact assignee selector in the sidebar, saves selected users with `assignee_id`, saves Unassigned as `assignee_id: null`, and refreshes the detail after a successful assignment update. Loading, success, and backend error states are visible inline in the assignment panel.

--- a/src/api/requestDetail.ts
+++ b/src/api/requestDetail.ts
@@ -14,6 +14,7 @@ export type RequestDetail = {
   statusCategory?: string;
   statusIsTerminal: boolean;
   priority: string;
+  assigneeId: string | null;
   assignee: string;
   requester: string;
   flow: string;
@@ -51,6 +52,13 @@ export type ApplyTransitionPayload = {
   comment?: string;
 };
 
+export type TenantUser = {
+  id: string;
+  label: string;
+  email?: string;
+  displayName?: string;
+};
+
 type AttachmentDto = {
   id?: string;
   attachmentid?: string;
@@ -76,6 +84,7 @@ type StatusDto = {
 };
 
 type UserDto = {
+  id?: string;
   user_id?: string;
   email?: string;
   display_name?: string;
@@ -93,6 +102,7 @@ type RequestDetailDto = {
   status?: string | StatusDto | null;
   statusid?: string;
   priority?: string;
+  assignee_id?: string | null;
   assignee?: string | UserDto | null;
   assignee_name?: string | null;
   requester?: string | UserDto | null;
@@ -136,6 +146,13 @@ type TransitionResponseDto = {
   transitions?: TransitionDto[];
 };
 
+type UserLookupResponseDto = {
+  results?: UserDto[];
+  users?: UserDto[];
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
   return {
     id: attachment.id ?? attachment.attachmentid ?? crypto.randomUUID(),
@@ -171,6 +188,35 @@ function displayUser(user?: string | UserDto | null, fallback?: string | null, e
   return user?.display_name ?? user?.email ?? fallback ?? empty;
 }
 
+function displayAssignee(user?: string | UserDto | null, fallback?: string | null) {
+  if (!user) return readableDisplay(fallback) ?? "Unassigned";
+  if (typeof user === "string") return readableDisplay(user) ?? readableDisplay(fallback) ?? "Unassigned";
+  return user.display_name ?? user.email ?? readableDisplay(fallback) ?? "Unassigned";
+}
+
+function readableDisplay(value?: string | null) {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || UUID_PATTERN.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function userId(user?: string | UserDto | null, fallback?: string | null) {
+  if (typeof user === "string") return fallback ?? null;
+  return user?.user_id ?? user?.id ?? fallback ?? null;
+}
+
+function normalizeTenantUser(user: UserDto): TenantUser {
+  const id = user.user_id ?? user.id ?? "";
+  const label = user.display_name ?? user.email ?? user.employee_code ?? id;
+  return {
+    id,
+    label,
+    email: user.email,
+    displayName: user.display_name,
+  };
+}
+
 function normalizeDetail(detail: RequestDetailDto): RequestDetail {
   return {
     id: detail.request_id ?? detail.human_id ?? detail.humanid ?? detail.requestid ?? "-",
@@ -180,7 +226,8 @@ function normalizeDetail(detail: RequestDetailDto): RequestDetail {
     statusCategory: statusCategory(detail.status),
     statusIsTerminal: statusIsTerminal(detail.status),
     priority: detail.priority ?? "-",
-    assignee: displayUser(detail.assignee, detail.assignee_name, "Unassigned"),
+    assigneeId: userId(detail.assignee, detail.assignee_id),
+    assignee: displayAssignee(detail.assignee, detail.assignee_name),
     requester: displayUser(detail.requester, detail.requester_name),
     flow: displayFlow(detail.flow, detail.flow_name),
     dueAt: detail.due_at,
@@ -224,6 +271,18 @@ export async function listRequestTransitions(requestId: string): Promise<Request
     ? response.data
     : response.data.transitions ?? response.data.results ?? [];
   return transitions.map(normalizeTransition).filter((transition) => transition.id);
+}
+
+export async function listTenantUsers(): Promise<TenantUser[]> {
+  const response = await api.get<UserLookupResponseDto | UserDto[]>("/users/");
+  const users = Array.isArray(response.data) ? response.data : response.data.users ?? response.data.results ?? [];
+  return users.map(normalizeTenantUser).filter((user) => user.id);
+}
+
+export async function updateRequestAssignee(requestId: string, assigneeId: string | null): Promise<void> {
+  await api.patch(`/requests/${encodeURIComponent(requestId)}/`, {
+    assignee_id: assigneeId,
+  });
 }
 
 export async function applyRequestTransition(requestId: string, payload: ApplyTransitionPayload) {

--- a/src/pages/RequestDetailPage.tsx
+++ b/src/pages/RequestDetailPage.tsx
@@ -2,12 +2,15 @@ import { useEffect, useMemo, useState } from "react";
 import { AxiosError } from "axios";
 import { useNavigate, useParams } from "react-router-dom";
 import {
-  RequestActivityEvent,
-  RequestDetail,
-  RequestTransition,
+  type RequestActivityEvent,
+  type RequestDetail,
+  type RequestTransition,
+  type TenantUser,
   applyRequestTransition,
   getRequestDetailBundle,
+  listTenantUsers,
   listRequestTransitions,
+  updateRequestAssignee,
 } from "../api/requestDetail";
 import { EmptyState } from "../components/common/EmptyState";
 import { ErrorState } from "../components/common/ErrorState";
@@ -22,6 +25,7 @@ const FALLBACK_DETAIL: RequestDetail = {
   status: "Open",
   statusIsTerminal: false,
   priority: "High",
+  assigneeId: "demo-assignee",
   assignee: "Ana Gomez",
   requester: "Carlos Diaz",
   flow: "IT Support",
@@ -317,6 +321,88 @@ function TransitionActions({
   );
 }
 
+function AssignmentControl({
+  currentAssignee,
+  currentAssigneeId,
+  users,
+  selectedAssigneeId,
+  loading,
+  saving,
+  error,
+  success,
+  onChange,
+  onSave,
+  onRetry,
+}: {
+  currentAssignee: string;
+  currentAssigneeId: string | null;
+  users: TenantUser[];
+  selectedAssigneeId: string;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  success: string | null;
+  onChange(assigneeId: string): void;
+  onSave(): void;
+  onRetry(): void;
+}) {
+  const normalizedCurrentId = currentAssigneeId ?? "";
+  const hasChanged = selectedAssigneeId !== normalizedCurrentId;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="text-xs font-semibold uppercase text-neutral-500">Current Assignee</div>
+        <div className="mt-1 text-sm font-semibold text-neutral-900">{currentAssignee}</div>
+      </div>
+      {success && (
+        <div className="rounded-lg border border-primary-600 bg-primary-50 px-3 py-2 text-sm font-semibold text-primary-700">
+          {success}
+        </div>
+      )}
+      <div>
+        <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="assignee-select">
+          Assign to
+        </label>
+        <select
+          id="assignee-select"
+          value={selectedAssigneeId}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={loading || saving}
+          className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50 disabled:cursor-not-allowed disabled:bg-neutral-50 disabled:text-neutral-500"
+        >
+          <option value="">Unassigned</option>
+          {users.map((user) => (
+            <option key={user.id} value={user.id}>
+              {user.label}
+              {user.email && user.email !== user.label ? ` (${user.email})` : ""}
+            </option>
+          ))}
+        </select>
+        <p className="mt-1 text-xs text-neutral-500">
+          {loading ? "Loading tenant users..." : "Unassigned is saved as null."}
+        </p>
+        {error && (
+          <div className="mt-2 rounded-lg border border-danger-500 bg-white px-3 py-2 text-xs text-danger-500">
+            <div>{error}</div>
+            <button type="button" className="mt-1 font-semibold underline" onClick={onRetry}>
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+      <button
+        type="button"
+        className="btn btn-secondary w-full"
+        onClick={onSave}
+        disabled={loading || saving || !hasChanged}
+      >
+        {saving ? "Saving" : "Save Assignment"}
+      </button>
+    </div>
+  );
+}
+
 export default function RequestDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -334,6 +420,14 @@ export default function RequestDetailPage() {
   const [transitionComment, setTransitionComment] = useState("");
   const [transitionSubmitting, setTransitionSubmitting] = useState(false);
   const [transitionSuccess, setTransitionSuccess] = useState<string | null>(null);
+  const [users, setUsers] = useState<TenantUser[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [usersError, setUsersError] = useState<string | null>(null);
+  const [selectedAssigneeId, setSelectedAssigneeId] = useState("");
+  const [assignmentSaving, setAssignmentSaving] = useState(false);
+  const [assignmentError, setAssignmentError] = useState<string | null>(null);
+  const [assignmentSuccess, setAssignmentSuccess] = useState<string | null>(null);
+  const [usersLoadAttempt, setUsersLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -410,6 +504,36 @@ export default function RequestDetailPage() {
     };
   }, [detail, loadAttempt, requestId]);
 
+  useEffect(() => {
+    setSelectedAssigneeId(detail?.assigneeId ?? "");
+  }, [detail?.assigneeId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadUsers() {
+      setUsersLoading(true);
+      try {
+        const nextUsers = await listTenantUsers();
+        if (cancelled) return;
+        setUsers(nextUsers);
+        setUsersError(null);
+      } catch (requestError) {
+        if (cancelled) return;
+        setUsers([]);
+        setUsersError(formatApiError(requestError, "Could not load tenant users."));
+      } finally {
+        if (!cancelled) setUsersLoading(false);
+      }
+    }
+
+    loadUsers();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [usersLoadAttempt]);
+
   async function submitTransition() {
     const selectedTransition = transitions.find((transition) => transition.id === selectedTransitionId);
     if (!requestId || !selectedTransition) return;
@@ -435,6 +559,23 @@ export default function RequestDetailPage() {
       setTransitionsError(formatApiError(requestError, "Could not apply the workflow action. Please try again."));
     } finally {
       setTransitionSubmitting(false);
+    }
+  }
+
+  async function saveAssignment() {
+    if (!requestId) return;
+
+    setAssignmentSaving(true);
+    setAssignmentError(null);
+    setAssignmentSuccess(null);
+    try {
+      await updateRequestAssignee(requestId, selectedAssigneeId || null);
+      setAssignmentSuccess("Assignment updated.");
+      setLoadAttempt((current) => current + 1);
+    } catch (requestError) {
+      setAssignmentError(formatApiError(requestError, "Could not update assignment. Please try again."));
+    } finally {
+      setAssignmentSaving(false);
     }
   }
 
@@ -529,7 +670,29 @@ export default function RequestDetailPage() {
           </section>
           <DetailField label="Status" value={detail.status} />
           <DetailField label="Priority" value={detail.priority} />
-          <DetailField label="Assignee" value={detail.assignee} />
+          <section className="space-y-3 border-y border-neutral-200 py-4">
+            <h2 className="text-sm font-semibold uppercase text-neutral-500">Assignment</h2>
+            <AssignmentControl
+              currentAssignee={detail.assignee}
+              currentAssigneeId={detail.assigneeId}
+              users={users}
+              selectedAssigneeId={selectedAssigneeId}
+              loading={usersLoading}
+              saving={assignmentSaving}
+              error={assignmentError ?? usersError}
+              success={assignmentSuccess}
+              onChange={(assigneeId) => {
+                setSelectedAssigneeId(assigneeId);
+                setAssignmentError(null);
+                setAssignmentSuccess(null);
+              }}
+              onSave={saveAssignment}
+              onRetry={() => {
+                setAssignmentError(null);
+                setUsersLoadAttempt((current) => current + 1);
+              }}
+            />
+          </section>
           <DetailField label="Requester" value={detail.requester} />
           <DetailField label="Flow" value={detail.flow} />
           <DetailField label="Due Date" value={formatDate(detail.dueAt)} />


### PR DESCRIPTION
## Summary
- switches Request Detail assignment user loading to GET /users/
- normalizes user list responses and stores user_id for assignment saves
- keeps Current Assignee readable and moves lookup errors near the dropdown
- updates the Sprint 2 ExecPlan notes

## Verification
- pnpm lint could not run because pnpm is not installed on PATH
- pnpm build could not run because pnpm is not installed on PATH
- .\\node_modules\\.bin\\tsc.CMD --noEmit
- .\\node_modules\\.bin\\eslint.CMD .
- .\\node_modules\\.bin\\vite.CMD build