### PR TITLE
feat(profile): add user preferences page

### DIFF
--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -115,6 +115,17 @@ Implementation steps:
 
 Add profile/preferences route or panel from user menu with display name, email, employee code, tenant info, and placeholder theme/density controls.
 
+Implementation steps:
+
+1. Add a protected `/profile/preferences` route in `src/main.tsx`.
+2. Wire the `Profile & Preferences` user-menu item in `src/pages/App.tsx` to navigate to `/profile/preferences`.
+3. Add a small JWT-claim normalizer in `src/auth/userProfile.ts` for display name, email, employee code, and username.
+4. Add `src/pages/ProfilePreferencesPage.tsx` with:
+   - Read-only profile fields from JWT claims.
+   - Tenant info from the existing auth context.
+   - Placeholder theme, density, and email notification controls saved locally.
+   - Compact loading-free UI that does not invent unsupported API endpoints.
+
 ## Tests and verification
 
 Run `pnpm lint`, `pnpm typecheck`, and `pnpm build` where available. Manually verify login, Home, create request, detail, comment/upload, transition/close, search, profile, logout.
@@ -162,6 +173,19 @@ Milestone 4 exact manual verification:
 5. Confirm the Open, In Progress, Due Today, and Overdue KPI cards show values from the summary response.
 6. Force or observe a summary endpoint failure and confirm Home shows a clear dashboard summary error without demo KPI values.
 
+Milestone 5 exact manual verification:
+
+1. Log in with a valid tenant.
+2. Open the user menu in the top bar.
+3. Click `Profile & Preferences`.
+4. Confirm the app navigates to `/profile/preferences`.
+5. Confirm the page shows display name, email, employee code, username, and tenant where available.
+6. Confirm missing profile fields render as `Not provided`, not raw objects or debug values.
+7. Change theme, density, or email notification preference and click `Save Preferences`.
+8. Confirm the success state appears and the page remains usable after reload.
+9. Confirm no unsupported profile API request is sent.
+10. Confirm Back to Home returns to `/`.
+
 ## Acceptance criteria
 
 Request Detail exists; Create Request works; transition/close works; dashboard summary is consumed; profile/preferences exists; states are implemented; UI follows tokens; auth and X-Tenant headers are sent.
@@ -200,6 +224,15 @@ Milestone 4 acceptance criteria:
 - The old four-request KPI count fan-out is removed.
 - Summary load failures show a clear error and do not display demo fallback KPI values.
 
+Milestone 5 acceptance criteria:
+
+- `/profile/preferences` is protected.
+- `Profile & Preferences` in the user menu opens `/profile/preferences`.
+- Profile fields render from JWT claims and tenant auth context without raw objects or placeholder alerts.
+- Theme, density, and email notification controls are visible and can be saved locally.
+- The page follows the existing compact app UI style and focus-visible behavior.
+- No unsupported API endpoints are called for profile/preferences.
+
 ## Progress
 
 - [x] Milestone 1 completed.
@@ -208,7 +241,7 @@ Milestone 4 acceptance criteria:
 - [x] Milestone 4 completed.
 - [x] Sprint 2 demo assignment sidebar fix completed.
 - [x] Sprint 2 assignment user endpoint/display fix completed.
-- [ ] Milestone 5 completed.
+- [x] Milestone 5 completed.
 
 ## Surprises & Discoveries
 
@@ -238,6 +271,7 @@ Milestone 4 acceptance criteria:
 - 2026-06-06: The existing tenant user lookup can feed a compact assignment dropdown; Unassigned must submit `assignee_id: null`, never an empty string.
 - 2026-06-08: The API exposes tenant users at `GET /users/`, not `/users/lookup/`; the assignment dropdown must use `/users/` and normalize either an array response or a paginated `results` response.
 - 2026-06-08: Current Assignee should be derived from `assignee.display_name` or `assignee.email`, with `Unassigned` as the safe fallback, so UUIDs, raw objects, and lookup errors do not appear as assignee text.
+- 2026-06-08: The web repo has no confirmed current-user/profile endpoint. The user profile page can use JWT claims and the existing auth tenant context for Sprint 2 without inventing a new API contract.
 
 ## Decision Log
 
@@ -262,6 +296,8 @@ Milestone 4 acceptance criteria:
 - 2026-06-06: Do not fall back to demo KPI values when the authenticated summary endpoint fails; show a clear error while keeping zero or last-known values.
 - 2026-06-06: Keep the assignment demo fix in the Request Detail sidebar and use the normal request partial update with `assignee_id`; this is a narrow lifecycle support control, not the full user profile/preferences milestone.
 - 2026-06-08: Use `GET /users/` for the Request Detail assignment user list and keep lookup failures scoped to a small dropdown error while preserving readable Current Assignee text.
+- 2026-06-08: Implement Milestone 5 as a protected `/profile/preferences` page rather than a modal so it is direct-linkable and keeps the user menu behavior simple.
+- 2026-06-08: Store placeholder theme/density/email-notification choices in localStorage for the Sprint 2 demo; defer server-backed preference persistence until an API contract exists.
 
 ## Outcomes & Retrospective
 
@@ -272,3 +308,5 @@ Milestone 3 outcome: Request Detail now loads allowed workflow actions from `GET
 Milestone 4 outcome: Home KPI cards now load from the dedicated `GET /dashboard/summary/` endpoint through the shared Axios client, normalizing summary response fields into Open, In Progress, Due Today, and Overdue values. The old four-call `/requests/` count fan-out was removed, and summary failures now show a clear error instead of demo KPI fallback values.
 
 Sprint 2 demo assignment fix outcome: Request Detail now loads tenant users from `GET /users/`, shows a compact assignee selector in the sidebar, saves selected users with `assignee_id`, saves Unassigned as `assignee_id: null`, and refreshes the detail after a successful assignment update. Loading, success, and backend error states are visible inline in the assignment panel.
+
+Milestone 5 outcome: `/profile/preferences` now exists as a protected page from the user menu. It shows display name, email, employee code, username, and tenant from JWT/auth context where available, renders missing values as `Not provided`, and provides local placeholder controls for theme, density, and email notifications. The top bar no longer hardcodes the user label and instead uses the decoded profile display name when present.

--- a/src/auth/userProfile.ts
+++ b/src/auth/userProfile.ts
@@ -1,0 +1,48 @@
+export type CurrentUserProfile = {
+  displayName: string;
+  email: string;
+  employeeCode: string;
+  username: string;
+};
+
+type JwtClaims = {
+  display_name?: string;
+  name?: string;
+  email?: string;
+  employee_code?: string;
+  employeeCode?: string;
+  preferred_username?: string;
+  username?: string;
+  sub?: string;
+};
+
+function decodeBase64Url(value: string) {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  return window.atob(padded);
+}
+
+function readJwtClaims(token: string | null): JwtClaims {
+  if (!token) return {};
+  const [, payload] = token.split(".");
+  if (!payload) return {};
+
+  try {
+    return JSON.parse(decodeBase64Url(payload)) as JwtClaims;
+  } catch {
+    return {};
+  }
+}
+
+export function getCurrentUserProfile(token: string | null): CurrentUserProfile {
+  const claims = readJwtClaims(token);
+  const email = claims.email ?? "";
+  const username = claims.preferred_username ?? claims.username ?? claims.sub ?? "";
+
+  return {
+    displayName: claims.display_name ?? claims.name ?? email ?? username,
+    email,
+    employeeCode: claims.employee_code ?? claims.employeeCode ?? "",
+    username,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from "./auth/useAuth";
 import "./index.css";
 import App from "./pages/App";
 import Login from "./pages/Login";
+import ProfilePreferencesPage from "./pages/ProfilePreferencesPage";
 import RequestCreatePage from "./pages/RequestCreatePage";
 import RequestDetailPage from "./pages/RequestDetailPage";
 
@@ -42,6 +43,14 @@ const router = createBrowserRouter([
     element: (
       <Protected>
         <RequestDetailPage />
+      </Protected>
+    ),
+  },
+  {
+    path: "/profile/preferences",
+    element: (
+      <Protected>
+        <ProfilePreferencesPage />
       </Protected>
     ),
   },

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { AxiosError } from "axios";
 import { HomePage } from "./HomePage";
 import { useAuth } from "../auth/useAuth";
+import { getCurrentUserProfile } from "../auth/userProfile";
 import {
   filterLocalSearchResults,
   RequestSearchFilters,
@@ -93,9 +94,8 @@ const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
   },
 ];
 
-function UserMenu({ onLogout }: { onLogout(): void }) {
+function UserMenu({ onLogout, onProfile }: { onLogout(): void; onProfile(): void }) {
   const menuItems = [
-    "Profile & Preferences",
     "Keyboard Shortcuts",
     "Saved Views",
     "Notifications",
@@ -104,6 +104,13 @@ function UserMenu({ onLogout }: { onLogout(): void }) {
 
   return (
     <div className="absolute right-6 top-16 z-20 w-64 rounded-lg border border-neutral-200 bg-white p-2 shadow-lg">
+      <button
+        type="button"
+        onClick={onProfile}
+        className="block w-full cursor-pointer rounded-lg px-3 py-2 text-left text-sm font-medium text-neutral-700 hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+      >
+        Profile & Preferences
+      </button>
       {menuItems.map((label) => (
         <button
           key={label}
@@ -124,7 +131,19 @@ function UserMenu({ onLogout }: { onLogout(): void }) {
   );
 }
 
-function TopBar({ tenant, onNew, onLogout }: { tenant?: string | null; onNew(): void; onLogout(): void }) {
+function TopBar({
+  tenant,
+  userName,
+  onNew,
+  onLogout,
+  onProfile,
+}: {
+  tenant?: string | null;
+  userName: string;
+  onNew(): void;
+  onLogout(): void;
+  onProfile(): void;
+}) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -145,9 +164,9 @@ function TopBar({ tenant, onNew, onLogout }: { tenant?: string | null; onNew(): 
           aria-expanded={open}
         >
           <div className="h-8 w-8 rounded-full bg-primary-600" />
-          <span className="text-sm font-medium text-neutral-800">Ana Gomez</span>
+          <span className="text-sm font-medium text-neutral-800">{userName || "User"}</span>
         </button>
-        {open && <UserMenu onLogout={onLogout} />}
+        {open && <UserMenu onLogout={onLogout} onProfile={onProfile} />}
       </div>
     </header>
   );
@@ -518,16 +537,19 @@ function SearchView() {
 }
 
 export default function App({ initialView = "home" }: { initialView?: AppView }) {
-  const { tenant, logout } = useAuth();
+  const { token, tenant, logout } = useAuth();
   const navigate = useNavigate();
   const [activeView, setActiveView] = useState<AppView>(initialView);
+  const userProfile = getCurrentUserProfile(token);
 
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50">
       <TopBar
         tenant={tenant}
+        userName={userProfile.displayName}
         onNew={() => navigate("/requests/new")}
         onLogout={logout}
+        onProfile={() => navigate("/profile/preferences")}
       />
       <div className="flex flex-1">
         <SideNav activeView={activeView} onNavigate={setActiveView} onNewRequest={() => navigate("/requests/new")} />

--- a/src/pages/ProfilePreferencesPage.tsx
+++ b/src/pages/ProfilePreferencesPage.tsx
@@ -1,0 +1,194 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/useAuth";
+import { getCurrentUserProfile } from "../auth/userProfile";
+
+type PreferenceState = {
+  theme: "system" | "light" | "dark";
+  density: "compact" | "comfortable";
+  emailNotifications: boolean;
+};
+
+const DEFAULT_PREFERENCES: PreferenceState = {
+  theme: "system",
+  density: "compact",
+  emailNotifications: true,
+};
+
+const STORAGE_KEY = "rt.profile.preferences";
+
+function readPreferences(): PreferenceState {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return DEFAULT_PREFERENCES;
+    return { ...DEFAULT_PREFERENCES, ...JSON.parse(stored) } as PreferenceState;
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+function writePreferences(preferences: PreferenceState) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+}
+
+function ProfileField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase text-neutral-500">{label}</div>
+      <div className="mt-1 min-h-10 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm font-semibold text-neutral-900">
+        {value || "Not provided"}
+      </div>
+    </div>
+  );
+}
+
+function PreferenceOption({
+  name,
+  value,
+  checked,
+  label,
+  onChange,
+}: {
+  name: string;
+  value: string;
+  checked: boolean;
+  label: string;
+  onChange(value: string): void;
+}) {
+  return (
+    <label
+      className={`inline-flex min-h-10 cursor-pointer items-center rounded-lg border px-3 text-sm font-semibold focus-within:outline focus-within:outline-2 focus-within:outline-primary-600 ${
+        checked ? "border-primary-600 bg-primary-50 text-primary-700" : "border-neutral-300 bg-white text-neutral-700"
+      }`}
+    >
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={(event) => onChange(event.target.value)}
+        className="sr-only"
+      />
+      {label}
+    </label>
+  );
+}
+
+export default function ProfilePreferencesPage() {
+  const navigate = useNavigate();
+  const { token, tenant } = useAuth();
+  const profile = getCurrentUserProfile(token);
+  const [preferences, setPreferences] = useState<PreferenceState>(DEFAULT_PREFERENCES);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setPreferences(readPreferences());
+  }, []);
+
+  function updatePreference<K extends keyof PreferenceState>(key: K, value: PreferenceState[K]) {
+    setPreferences((current) => ({ ...current, [key]: value }));
+    setSaved(false);
+  }
+
+  function submitPreferences(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    writePreferences(preferences);
+    setSaved(true);
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-b border-neutral-200 bg-white px-6 py-4">
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          className="mb-3 rounded-lg border border-neutral-300 px-3 py-2 text-sm font-semibold text-neutral-700 hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+        >
+          Back to Home
+        </button>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-neutral-900">Profile & Preferences</h1>
+            <div className="mt-1 text-sm font-semibold text-neutral-500">{profile.displayName || "User"}</div>
+          </div>
+          <div className="rounded-lg border border-neutral-300 bg-neutral-100 px-3 py-1 text-sm font-semibold text-neutral-700">
+            Tenant: {tenant ?? "-"}
+          </div>
+        </div>
+      </header>
+
+      <main className="grid grid-cols-[minmax(0,1fr)_320px] gap-4 p-6">
+        <section className="card p-4">
+          <h2 className="text-lg font-semibold text-neutral-900">Profile</h2>
+          <div className="mt-4 grid grid-cols-2 gap-4">
+            <ProfileField label="Display Name" value={profile.displayName} />
+            <ProfileField label="Email" value={profile.email} />
+            <ProfileField label="Employee Code" value={profile.employeeCode} />
+            <ProfileField label="Username" value={profile.username} />
+            <ProfileField label="Tenant" value={tenant ?? ""} />
+          </div>
+        </section>
+
+        <aside className="card h-fit p-4">
+          <h2 className="text-sm font-semibold uppercase text-neutral-500">Preferences</h2>
+          <form className="mt-4 space-y-5" onSubmit={submitPreferences}>
+            <fieldset>
+              <legend className="text-sm font-semibold text-neutral-800">Theme</legend>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(["system", "light", "dark"] as const).map((theme) => (
+                  <PreferenceOption
+                    key={theme}
+                    name="theme"
+                    value={theme}
+                    label={theme[0].toUpperCase() + theme.slice(1)}
+                    checked={preferences.theme === theme}
+                    onChange={(value) => updatePreference("theme", value as PreferenceState["theme"])}
+                  />
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend className="text-sm font-semibold text-neutral-800">Density</legend>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(["compact", "comfortable"] as const).map((density) => (
+                  <PreferenceOption
+                    key={density}
+                    name="density"
+                    value={density}
+                    label={density[0].toUpperCase() + density.slice(1)}
+                    checked={preferences.density === density}
+                    onChange={(value) => updatePreference("density", value as PreferenceState["density"])}
+                  />
+                ))}
+              </div>
+            </fieldset>
+
+            <label className="flex items-center gap-2 text-sm font-semibold text-neutral-800">
+              <input
+                type="checkbox"
+                checked={preferences.emailNotifications}
+                onChange={(event) => updatePreference("emailNotifications", event.target.checked)}
+                className="h-4 w-4 rounded border-neutral-300 text-primary-600 focus:ring-primary-600"
+              />
+              Email notifications
+            </label>
+
+            {saved && (
+              <div className="rounded-lg border border-primary-600 bg-primary-50 px-3 py-2 text-sm font-semibold text-primary-700">
+                Preferences saved.
+              </div>
+            )}
+
+            <button type="submit" className="btn btn-primary w-full">
+              Save Preferences
+            </button>
+          </form>
+        </aside>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- adds protected /profile/preferences route
- wires Profile & Preferences from the top-bar user menu
- decodes basic JWT profile claims for display name, email, employee code, and username
- adds local placeholder preferences for theme, density, and email notifications
- updates the Sprint 2 ExecPlan for Milestone 5

## Verification
- pnpm lint could not run because pnpm is not installed on PATH
- pnpm build could not run because pnpm is not installed on PATH
- .\\node_modules\\.bin\\tsc.CMD --noEmit
- .\\node_modules\\.bin\\eslint.CMD .
- .\\node_modules\\.bin\\vite.CMD build
- npm.cmd run typecheck
- npm.cmd run lint
- npm.cmd run build
- built app route smoke: GET http://127.0.0.1:4173/profile/preferences returned 200