### PR TITLE
chore(sprint2): harden web demo flows

### DIFF
--- a/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
+++ b/docs/plans/sprint-2/web-full-request-lifecycle-execplan.md
@@ -126,6 +126,17 @@ Implementation steps:
    - Placeholder theme, density, and email notification controls saved locally.
    - Compact loading-free UI that does not invent unsupported API endpoints.
 
+### Milestone 6: Sprint 2 hardening/demo pass
+
+Fix demo-blocking issues found during manual testing:
+
+1. Home search navigates immediately to `/search?q=<query>` from the current input value and includes a clear action.
+2. Search uses the authenticated API endpoint `GET /search/requests` and does not show local demo rows in real app flows.
+3. Home and Search rows normalize nested `status`, `assignee`, `requester`, and `flow` shapes and enrich rows from Request Detail when list/search responses only include IDs.
+4. Request Detail loads attachments from both detail payloads and `GET /requests/{request_id}/attachments/`.
+5. Request Detail exposes a comment/upload form that uses `POST /attachments/init`, PUTs files to pre-signed URLs, then calls `POST /attachments/finalize`.
+6. Authenticated flows show clear empty/error states instead of demo data fallbacks.
+
 ## Tests and verification
 
 Run `pnpm lint`, `pnpm typecheck`, and `pnpm build` where available. Manually verify login, Home, create request, detail, comment/upload, transition/close, search, profile, logout.
@@ -186,6 +197,18 @@ Milestone 5 exact manual verification:
 9. Confirm no unsupported profile API request is sent.
 10. Confirm Back to Home returns to `/`.
 
+Milestone 6 exact manual verification:
+
+1. From Home, type `vpn` and click Search.
+2. Confirm the app navigates immediately to `/search?q=vpn`.
+3. Confirm Search calls `GET /api/search/requests?q=vpn` with `Authorization` and `X-Tenant`.
+4. Confirm Search shows real API rows or a clear API error, never local demo rows.
+5. Confirm Home rows show status, assignee, requester, and flow as readable text where the API provides or detail enrichment can resolve them.
+6. Open a Request Detail page with attachments uploaded from API/Postman and confirm they render in Attachments.
+7. Add a comment with one or more files from Request Detail.
+8. Confirm the web calls `POST /api/attachments/init`, PUTs each file to its pre-signed URL, then calls `POST /api/attachments/finalize`.
+9. Confirm the detail page refreshes and shows the new grouped comment/attachments.
+
 ## Acceptance criteria
 
 Request Detail exists; Create Request works; transition/close works; dashboard summary is consumed; profile/preferences exists; states are implemented; UI follows tokens; auth and X-Tenant headers are sent.
@@ -233,6 +256,16 @@ Milestone 5 acceptance criteria:
 - The page follows the existing compact app UI style and focus-visible behavior.
 - No unsupported API endpoints are called for profile/preferences.
 
+Milestone 6 acceptance criteria:
+
+- Home search submits the current input value immediately and does not trigger delayed navigation after returning from detail.
+- Search uses `GET /search/requests` through the shared Axios client.
+- Search and Home do not show local demo rows for authenticated API failures.
+- Home/Search request rows never render raw objects and show readable status, assignee, requester, and flow where available.
+- Request Detail renders existing attachments from the API.
+- Request Detail supports grouped multi-file upload with an optional comment through init/upload/finalize.
+- Upload success refreshes detail, comments, attachments, and activity.
+
 ## Progress
 
 - [x] Milestone 1 completed.
@@ -242,6 +275,7 @@ Milestone 5 acceptance criteria:
 - [x] Sprint 2 demo assignment sidebar fix completed.
 - [x] Sprint 2 assignment user endpoint/display fix completed.
 - [x] Milestone 5 completed.
+- [x] Milestone 6 Sprint 2 hardening/demo pass completed.
 
 ## Surprises & Discoveries
 
@@ -272,6 +306,10 @@ Milestone 5 acceptance criteria:
 - 2026-06-08: The API exposes tenant users at `GET /users/`, not `/users/lookup/`; the assignment dropdown must use `/users/` and normalize either an array response or a paginated `results` response.
 - 2026-06-08: Current Assignee should be derived from `assignee.display_name` or `assignee.email`, with `Unassigned` as the safe fallback, so UUIDs, raw objects, and lookup errors do not appear as assignee text.
 - 2026-06-08: The web repo has no confirmed current-user/profile endpoint. The user profile page can use JWT claims and the existing auth tenant context for Sprint 2 without inventing a new API contract.
+- 2026-06-09: Search had two real-flow demo hazards: it still called `/search` instead of the confirmed `/search/requests` route, and it showed local fixture rows on API failure.
+- 2026-06-09: Request list and search responses can contain only public IDs for status/assignee/requester/flow; the web needs safe display normalizers plus detail enrichment to render readable names in Sprint 2 demos.
+- 2026-06-09: Existing attachments may be available through `GET /requests/{request_id}/attachments/` even when the detail payload does not embed them.
+- 2026-06-09: The current upload API is the global grouped flow: `POST /attachments/init`, PUT to pre-signed URLs, then `POST /attachments/finalize`; the older request-local presign endpoint is not the demo path.
 
 ## Decision Log
 
@@ -298,6 +336,10 @@ Milestone 5 acceptance criteria:
 - 2026-06-08: Use `GET /users/` for the Request Detail assignment user list and keep lookup failures scoped to a small dropdown error while preserving readable Current Assignee text.
 - 2026-06-08: Implement Milestone 5 as a protected `/profile/preferences` page rather than a modal so it is direct-linkable and keeps the user menu behavior simple.
 - 2026-06-08: Store placeholder theme/density/email-notification choices in localStorage for the Sprint 2 demo; defer server-backed preference persistence until an API contract exists.
+- 2026-06-09: Remove local demo fallback rows from authenticated Home/Search flows. API failures now leave rows empty and show clear errors.
+- 2026-06-09: Use a shared request display normalizer for nested/string/ID-ish status, assignee, requester, and flow fields so raw objects and UUIDs do not leak into tables.
+- 2026-06-09: Enrich Home/Search rows with Request Detail data when the list/search endpoint returns IDs only. If enrichment for one row fails, keep the base row instead of failing the whole page.
+- 2026-06-09: Keep grouped upload UI inside Request Detail Comments so comments and attachments are created as one visible conversation event.
 
 ## Outcomes & Retrospective
 
@@ -310,3 +352,5 @@ Milestone 4 outcome: Home KPI cards now load from the dedicated `GET /dashboard/
 Sprint 2 demo assignment fix outcome: Request Detail now loads tenant users from `GET /users/`, shows a compact assignee selector in the sidebar, saves selected users with `assignee_id`, saves Unassigned as `assignee_id: null`, and refreshes the detail after a successful assignment update. Loading, success, and backend error states are visible inline in the assignment panel.
 
 Milestone 5 outcome: `/profile/preferences` now exists as a protected page from the user menu. It shows display name, email, employee code, username, and tenant from JWT/auth context where available, renders missing values as `Not provided`, and provides local placeholder controls for theme, density, and email notifications. The top bar no longer hardcodes the user label and instead uses the decoded profile display name when present.
+
+Milestone 6 outcome: Sprint 2 hardening removed local search/dashboard demo fallbacks from authenticated flows, switched Search to `GET /search/requests`, synchronized Search state from the URL query, added Home search clear behavior, normalized request display fields through a shared helper, enriched Home/Search rows from Request Detail when needed, loaded Request Detail attachments from the attachments endpoint, and added visible grouped comment/file upload using the API init/upload/finalize flow.

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -1,4 +1,15 @@
 import api from "../lib/api";
+import { getRequestDetail } from "./requestDetail";
+import {
+  displayAssignee,
+  displayFlow,
+  displayStatus,
+  displayUser,
+  statusCategory,
+  type FlowDto,
+  type StatusDto,
+  type UserDto,
+} from "./requestDisplay";
 
 export type DashboardRequest = {
   id: string;
@@ -43,10 +54,15 @@ type RequestDto = {
   human_id?: string;
   title?: string;
   statusid?: string;
+  status_id?: string;
+  status_name?: string;
+  status_category?: string;
   status?: string | StatusDto | null;
   priority?: string;
+  assignee_id?: string | null;
   assignee?: string | UserDto | null;
   assignee_name?: string | null;
+  requester_id?: string | null;
   requester?: string | UserDto | null;
   requester_name?: string | null;
   updated_at?: string;
@@ -75,62 +91,46 @@ type DashboardSummaryDto = {
   counts?: DashboardSummaryDto;
 };
 
-type FlowDto = {
-  flow_id?: string;
-  name?: string;
-  description?: string;
-};
-
-type StatusDto = {
-  status_id?: string;
-  name?: string;
-  category?: string;
-  is_terminal?: boolean;
-};
-
-type UserDto = {
-  user_id?: string;
-  email?: string;
-  display_name?: string;
-  employee_code?: string;
-  avatar_url?: string;
-};
-
-function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
-  if (typeof flow === "string") return flow;
-  return flow?.name ?? fallback ?? "-";
-}
-
-function displayStatus(status?: string | StatusDto | null, fallback?: string) {
-  if (typeof status === "string") return status;
-  return status?.name ?? fallback ?? "-";
-}
-
-function statusCategory(status?: string | StatusDto | null) {
-  if (!status || typeof status === "string") return undefined;
-  return status.category;
-}
-
-function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
-  if (typeof user === "string") return user;
-  return user?.display_name ?? user?.email ?? fallback ?? empty;
-}
-
 function normalizeRequest(request: RequestDto): DashboardRequest {
   const requestId = request.request_id ?? "";
   return {
     id: (request.human_id ?? request.humanid ?? requestId) || request.requestid || "-",
     requestId,
     title: request.title ?? "Untitled request",
-    status: displayStatus(request.status, request.statusid),
-    statusCategory: statusCategory(request.status),
+    status: displayStatus(request.status, request.status_name ?? request.status_category ?? request.statusid ?? request.status_id),
+    statusCategory: statusCategory(request.status, request.status_category),
     priority: request.priority ?? "-",
-    assignee: displayUser(request.assignee, request.assignee_name, "Unassigned"),
+    assignee: displayAssignee(request.assignee, request.assignee_name),
     requester: displayUser(request.requester, request.requester_name),
     updatedAt: request.updated_at ?? "",
     flow: displayFlow(request.flow, request.flow_name),
     dueAt: request.due_at,
   };
+}
+
+async function enrichRequestsWithDetail(requests: DashboardRequest[]) {
+  const enriched = await Promise.all(
+    requests.map(async (request) => {
+      if (!request.requestId) return request;
+      try {
+        const detail = await getRequestDetail(request.requestId);
+        return {
+          ...request,
+          status: detail.status,
+          statusCategory: detail.statusCategory,
+          assignee: detail.assignee,
+          requester: detail.requester,
+          flow: detail.flow,
+          priority: detail.priority,
+          dueAt: detail.dueAt,
+          updatedAt: detail.updatedAt || request.updatedAt,
+        };
+      } catch {
+        return request;
+      }
+    }),
+  );
+  return enriched;
 }
 
 function normalizeList(data: RequestListDto | RequestDto[]): DashboardListResponse {
@@ -186,5 +186,9 @@ export async function getDashboardRequests(params: DashboardListParams): Promise
   const response = await api.get<RequestListDto | RequestDto[]>("/requests/", {
     params: paramsForList(params),
   });
-  return normalizeList(response.data);
+  const normalized = normalizeList(response.data);
+  return {
+    ...normalized,
+    results: await enrichRequestsWithDetail(normalized.results),
+  };
 }

--- a/src/api/requestDetail.ts
+++ b/src/api/requestDetail.ts
@@ -3,8 +3,22 @@ import {
   RequestComment,
   RequestCommentAttachment,
   createRequestComment,
+  listRequestAttachments,
   listRequestComments,
+  normalizeAttachment,
 } from "../features/requestActivity";
+import {
+  displayAssignee,
+  displayFlow,
+  displayStatus,
+  displayUser,
+  statusCategory,
+  statusIsTerminal,
+  userId,
+  type FlowDto,
+  type StatusDto,
+  type UserDto,
+} from "./requestDisplay";
 
 export type RequestDetail = {
   id: string;
@@ -62,34 +76,19 @@ export type TenantUser = {
 type AttachmentDto = {
   id?: string;
   attachmentid?: string;
+  attachment_id?: string;
   file_name?: string;
   filename?: string;
   size?: number;
+  sizebytes?: number;
+  size_bytes?: number;
   content_type?: string;
+  contenttype?: string;
   scan_status?: "pending" | "clean" | "blocked";
+  scanstatus?: "pending" | "clean" | "blocked";
   download_url?: string;
-};
-
-type FlowDto = {
-  flow_id?: string;
-  name?: string;
-  description?: string;
-};
-
-type StatusDto = {
-  status_id?: string;
-  name?: string;
-  category?: string;
-  is_terminal?: boolean;
-};
-
-type UserDto = {
-  id?: string;
-  user_id?: string;
-  email?: string;
-  display_name?: string;
-  employee_code?: string;
-  avatar_url?: string;
+  storageurl?: string;
+  storage_url?: string;
 };
 
 type RequestDetailDto = {
@@ -101,6 +100,8 @@ type RequestDetailDto = {
   description?: string;
   status?: string | StatusDto | null;
   statusid?: string;
+  status_name?: string;
+  status_category?: string;
   priority?: string;
   assignee_id?: string | null;
   assignee?: string | UserDto | null;
@@ -151,61 +152,6 @@ type UserLookupResponseDto = {
   users?: UserDto[];
 };
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
-  return {
-    id: attachment.id ?? attachment.attachmentid ?? crypto.randomUUID(),
-    fileName: attachment.file_name ?? attachment.filename ?? "Attachment",
-    size: attachment.size ?? 0,
-    contentType: attachment.content_type,
-    scanStatus: attachment.scan_status,
-    downloadUrl: attachment.download_url,
-  };
-}
-
-function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
-  if (typeof flow === "string") return flow;
-  return flow?.name ?? fallback ?? "-";
-}
-
-function displayStatus(status?: string | StatusDto | null, fallback?: string) {
-  if (typeof status === "string") return status;
-  return status?.name ?? fallback ?? "-";
-}
-
-function statusCategory(status?: string | StatusDto | null) {
-  if (!status || typeof status === "string") return undefined;
-  return status.category;
-}
-
-function statusIsTerminal(status?: string | StatusDto | null) {
-  return Boolean(status && typeof status !== "string" && status.is_terminal);
-}
-
-function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
-  if (typeof user === "string") return user;
-  return user?.display_name ?? user?.email ?? fallback ?? empty;
-}
-
-function displayAssignee(user?: string | UserDto | null, fallback?: string | null) {
-  if (!user) return readableDisplay(fallback) ?? "Unassigned";
-  if (typeof user === "string") return readableDisplay(user) ?? readableDisplay(fallback) ?? "Unassigned";
-  return user.display_name ?? user.email ?? readableDisplay(fallback) ?? "Unassigned";
-}
-
-function readableDisplay(value?: string | null) {
-  if (!value) return undefined;
-  const trimmed = value.trim();
-  if (!trimmed || UUID_PATTERN.test(trimmed)) return undefined;
-  return trimmed;
-}
-
-function userId(user?: string | UserDto | null, fallback?: string | null) {
-  if (typeof user === "string") return fallback ?? null;
-  return user?.user_id ?? user?.id ?? fallback ?? null;
-}
-
 function normalizeTenantUser(user: UserDto): TenantUser {
   const id = user.user_id ?? user.id ?? "";
   const label = user.display_name ?? user.email ?? user.employee_code ?? id;
@@ -222,8 +168,8 @@ function normalizeDetail(detail: RequestDetailDto): RequestDetail {
     id: detail.request_id ?? detail.human_id ?? detail.humanid ?? detail.requestid ?? "-",
     title: detail.title ?? "Untitled request",
     description: detail.description ?? "",
-    status: displayStatus(detail.status, detail.statusid),
-    statusCategory: statusCategory(detail.status),
+    status: displayStatus(detail.status, detail.status_name ?? detail.status_category ?? detail.statusid),
+    statusCategory: statusCategory(detail.status, detail.status_category),
     statusIsTerminal: statusIsTerminal(detail.status),
     priority: detail.priority ?? "-",
     assigneeId: userId(detail.assignee, detail.assignee_id),
@@ -313,12 +259,21 @@ export async function getRequestActivity(requestId: string): Promise<RequestActi
 
 export async function getRequestDetailBundle(requestId: string): Promise<RequestDetailBundle> {
   const detail = await getRequestDetail(requestId);
-  const [commentsResult, activityResult] = await Promise.allSettled([
+  const [commentsResult, attachmentsResult, activityResult] = await Promise.allSettled([
     listRequestComments(requestId),
+    listRequestAttachments(requestId),
     getRequestActivity(requestId),
   ]);
   const comments = commentsResult.status === "fulfilled" ? commentsResult.value : [];
+  const externalAttachments = attachmentsResult.status === "fulfilled" ? attachmentsResult.value : [];
   const activity = activityResult.status === "fulfilled" ? activityResult.value : [];
 
-  return { detail, comments, activity };
+  return {
+    detail: {
+      ...detail,
+      attachments: [...detail.attachments, ...externalAttachments],
+    },
+    comments,
+    activity,
+  };
 }

--- a/src/api/requestDisplay.ts
+++ b/src/api/requestDisplay.ts
@@ -1,0 +1,63 @@
+export type FlowDto = {
+  flow_id?: string;
+  name?: string;
+  description?: string;
+};
+
+export type StatusDto = {
+  status_id?: string;
+  name?: string;
+  category?: string;
+  is_terminal?: boolean;
+};
+
+export type UserDto = {
+  id?: string;
+  user_id?: string;
+  email?: string;
+  display_name?: string;
+  employee_code?: string;
+  avatar_url?: string;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function readableDisplay(value?: string | null) {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || UUID_PATTERN.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function displayFlow(flow?: string | FlowDto | null, fallback?: string | null) {
+  if (typeof flow === "string") return readableDisplay(flow) ?? readableDisplay(fallback) ?? "-";
+  return flow?.name ?? readableDisplay(fallback) ?? "-";
+}
+
+export function displayStatus(status?: string | StatusDto | null, fallback?: string | null) {
+  if (typeof status === "string") return readableDisplay(status) ?? readableDisplay(fallback) ?? "-";
+  return status?.name ?? status?.category ?? readableDisplay(fallback) ?? "-";
+}
+
+export function statusCategory(status?: string | StatusDto | null, fallback?: string | null) {
+  if (!status || typeof status === "string") return readableDisplay(fallback);
+  return status.category;
+}
+
+export function statusIsTerminal(status?: string | StatusDto | null) {
+  return Boolean(status && typeof status !== "string" && status.is_terminal);
+}
+
+export function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
+  if (typeof user === "string") return readableDisplay(user) ?? readableDisplay(fallback) ?? empty;
+  return user?.display_name ?? user?.email ?? readableDisplay(fallback) ?? empty;
+}
+
+export function displayAssignee(user?: string | UserDto | null, fallback?: string | null) {
+  return displayUser(user, fallback, "Unassigned");
+}
+
+export function userId(user?: string | UserDto | null, fallback?: string | null) {
+  if (typeof user === "string") return fallback ?? null;
+  return user?.user_id ?? user?.id ?? fallback ?? null;
+}

--- a/src/features/requestActivity.ts
+++ b/src/features/requestActivity.ts
@@ -32,12 +32,19 @@ type CommentDto = {
 type AttachmentDto = {
   id?: string;
   attachmentid?: string;
+  attachment_id?: string;
   file_name?: string;
   filename?: string;
   size?: number;
+  sizebytes?: number;
+  size_bytes?: number;
   content_type?: string;
+  contenttype?: string;
   scan_status?: "pending" | "clean" | "blocked";
+  scanstatus?: "pending" | "clean" | "blocked";
   download_url?: string;
+  storageurl?: string;
+  storage_url?: string;
 };
 
 type CommentsResponse = {
@@ -45,6 +52,8 @@ type CommentsResponse = {
 };
 
 type PresignResponse = {
+  request_id?: string;
+  group_id?: string;
   uploads?: PresignedUploadDto[];
 };
 
@@ -54,21 +63,21 @@ type PresignedUploadDto = {
   upload_url?: string;
   url?: string;
   file_name?: string;
+  filename?: string;
+  content_type?: string;
+  size_bytes?: number;
+  object_key?: string;
+  headers?: Record<string, string>;
 };
 
-export type SelectedUpload = {
-  file: File;
-  localId: string;
-};
-
-function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
+export function normalizeAttachment(attachment: AttachmentDto): RequestCommentAttachment {
   return {
-    id: attachment.id ?? attachment.attachmentid ?? crypto.randomUUID(),
+    id: attachment.id ?? attachment.attachment_id ?? attachment.attachmentid ?? crypto.randomUUID(),
     fileName: attachment.file_name ?? attachment.filename ?? "Attachment",
-    size: attachment.size ?? 0,
-    contentType: attachment.content_type,
-    scanStatus: attachment.scan_status,
-    downloadUrl: attachment.download_url,
+    size: attachment.size ?? attachment.size_bytes ?? attachment.sizebytes ?? 0,
+    contentType: attachment.content_type ?? attachment.contenttype,
+    scanStatus: attachment.scan_status ?? attachment.scanstatus,
+    downloadUrl: attachment.download_url ?? attachment.storage_url ?? attachment.storageurl,
   };
 }
 
@@ -91,21 +100,34 @@ export async function listRequestComments(requestId: string) {
   return comments.map(normalizeComment);
 }
 
-async function presignUploads(requestId: string, files: File[]) {
-  if (files.length === 0) return [];
+export async function listRequestAttachments(requestId: string) {
+  const response = await api.get<{ results?: AttachmentDto[] } | AttachmentDto[]>(
+    `/requests/${encodeURIComponent(requestId)}/attachments/`,
+    { params: { page_size: 50, sort: "-created_at" } },
+  );
+  const attachments = Array.isArray(response.data) ? response.data : response.data.results ?? [];
+  return attachments.map(normalizeAttachment);
+}
+
+async function initUploads(requestId: string, files: File[]) {
+  if (files.length === 0) return { groupId: "", uploads: [] };
 
   const response = await api.post<PresignResponse | PresignedUploadDto[]>(
-    `/requests/${encodeURIComponent(requestId)}/attachments/presign/`,
+    "/attachments/init",
     {
+      request_id: requestId,
       files: files.map((file) => ({
         filename: file.name,
         content_type: file.type || "application/octet-stream",
-        size: file.size,
+        size_bytes: file.size,
       })),
     },
   );
 
-  return Array.isArray(response.data) ? response.data : response.data.uploads ?? [];
+  return {
+    groupId: Array.isArray(response.data) ? "" : response.data.group_id ?? "",
+    uploads: Array.isArray(response.data) ? response.data : response.data.uploads ?? [],
+  };
 }
 
 async function uploadFilesToStorage(files: File[], uploads: PresignedUploadDto[]) {
@@ -117,39 +139,52 @@ async function uploadFilesToStorage(files: File[], uploads: PresignedUploadDto[]
         throw new Error(`Missing upload URL for ${file.name}`);
       }
       return axios.put(uploadUrl, file, {
-        headers: { "Content-Type": file.type || "application/octet-stream" },
+        headers: upload.headers ?? { "Content-Type": file.type || "application/octet-stream" },
       });
     }),
   );
 }
 
 export async function createRequestComment(requestId: string, body: string, files: File[]) {
-  const uploads = await presignUploads(requestId, files);
+  if (files.length === 0) {
+    const response = await api.post<CommentDto>(
+      `/requests/${encodeURIComponent(requestId)}/comments/`,
+      { body },
+    );
+
+    return normalizeComment(response.data);
+  }
+
+  const { groupId, uploads } = await initUploads(requestId, files);
   await uploadFilesToStorage(files, uploads);
 
-  const response = await api.post<CommentDto>(
-    `/requests/${encodeURIComponent(requestId)}/comments/`,
+  const response = await api.post<{
+    comment_id?: string;
+    group_id?: string;
+    attachments?: AttachmentDto[];
+  }>(
+    "/attachments/finalize",
     {
-      body,
-      attachments: uploads.map((upload) => upload.attachment_id ?? upload.id).filter(Boolean),
+      request_id: requestId,
+      group_id: groupId,
+      comment_markdown: body,
+      files: uploads.map((upload, index) => {
+        const file = files[index];
+        return {
+          object_key: upload.object_key,
+          filename: upload.filename ?? upload.file_name ?? file.name,
+          content_type: (upload.content_type ?? file.type) || undefined,
+          size_bytes: upload.size_bytes ?? file.size,
+        };
+      }),
     },
   );
 
-  return normalizeComment(response.data);
-}
-
-export function makeLocalComment(body: string, files: File[]): RequestComment {
   return {
-    id: crypto.randomUUID(),
-    authorName: "Ana Gomez",
+    id: response.data.comment_id ?? crypto.randomUUID(),
+    authorName: "Current user",
     body,
     createdAt: new Date().toISOString(),
-    attachments: files.map((file) => ({
-      id: crypto.randomUUID(),
-      fileName: file.name,
-      size: file.size,
-      contentType: file.type,
-      scanStatus: "pending",
-    })),
+    attachments: (response.data.attachments ?? []).map(normalizeAttachment),
   };
 }

--- a/src/features/requestSearch.ts
+++ b/src/features/requestSearch.ts
@@ -1,4 +1,15 @@
 import api from "../lib/api";
+import { getRequestDetail } from "../api/requestDetail";
+import {
+  displayAssignee,
+  displayFlow,
+  displayStatus,
+  displayUser,
+  statusCategory,
+  type FlowDto,
+  type StatusDto,
+  type UserDto,
+} from "../api/requestDisplay";
 
 export type SearchFacetKey = "status" | "assignee" | "flow" | "tag";
 
@@ -22,6 +33,7 @@ export type RequestSearchResult = {
   status: string;
   statusCategory?: string;
   assignee: string;
+  requester: string;
   flow: string;
   tags: string[];
   updatedAt: string;
@@ -40,9 +52,15 @@ type SearchResultDto = {
   human_id?: string;
   title?: string;
   statusid?: string;
+  status_id?: string;
+  status_name?: string;
+  status_category?: string;
   status?: string | StatusDto | null;
+  assignee_id?: string | null;
   assignee?: string | UserDto | null;
   assignee_name?: string | null;
+  requester?: string | UserDto | null;
+  requester_name?: string | null;
   flow?: string | FlowDto | null;
   flow_name?: string;
   tags?: string[];
@@ -56,61 +74,45 @@ type SearchResponseDto = {
   count?: number;
 };
 
-type FlowDto = {
-  flow_id?: string;
-  name?: string;
-  description?: string;
-};
-
-type StatusDto = {
-  status_id?: string;
-  name?: string;
-  category?: string;
-  is_terminal?: boolean;
-};
-
-type UserDto = {
-  user_id?: string;
-  email?: string;
-  display_name?: string;
-  employee_code?: string;
-  avatar_url?: string;
-};
-
-function displayFlow(flow?: string | FlowDto | null, fallback?: string) {
-  if (typeof flow === "string") return flow;
-  return flow?.name ?? fallback ?? "-";
-}
-
-function displayStatus(status?: string | StatusDto | null, fallback?: string) {
-  if (typeof status === "string") return status;
-  return status?.name ?? fallback ?? "-";
-}
-
-function statusCategory(status?: string | StatusDto | null) {
-  if (!status || typeof status === "string") return undefined;
-  return status.category;
-}
-
-function displayUser(user?: string | UserDto | null, fallback?: string | null, empty = "-") {
-  if (typeof user === "string") return user;
-  return user?.display_name ?? user?.email ?? fallback ?? empty;
-}
-
 function normalizeSearchResult(result: SearchResultDto): RequestSearchResult {
   const requestId = result.request_id ?? "";
   return {
     id: (result.human_id ?? result.humanid ?? requestId) || result.requestid || "-",
     requestId,
     title: result.title ?? "Untitled request",
-    status: displayStatus(result.status, result.statusid),
-    statusCategory: statusCategory(result.status),
-    assignee: displayUser(result.assignee, result.assignee_name, "Unassigned"),
+    status: displayStatus(result.status, result.status_name ?? result.status_category ?? result.statusid ?? result.status_id),
+    statusCategory: statusCategory(result.status, result.status_category),
+    assignee: displayAssignee(result.assignee, result.assignee_name),
+    requester: displayUser(result.requester, result.requester_name),
     flow: displayFlow(result.flow, result.flow_name),
     tags: result.tags ?? [],
     updatedAt: result.updated_at ?? "",
     snippet: result.snippet ?? result.highlight ?? "",
   };
+}
+
+async function enrichSearchResultsWithDetail(results: RequestSearchResult[]) {
+  return Promise.all(
+    results.map(async (result) => {
+      if (!result.requestId) return result;
+      try {
+        const detail = await getRequestDetail(result.requestId);
+        return {
+          ...result,
+          title: detail.title,
+          status: detail.status,
+          statusCategory: detail.statusCategory,
+          assignee: detail.assignee,
+          requester: detail.requester,
+          flow: detail.flow,
+          updatedAt: detail.updatedAt || result.updatedAt,
+          snippet: result.snippet || detail.description,
+        };
+      } catch {
+        return result;
+      }
+    }),
+  );
 }
 
 function appendListParam(params: URLSearchParams, key: string, values: string[]) {
@@ -135,50 +137,13 @@ export function buildSearchParams(filters: RequestSearchFilters) {
 }
 
 export async function searchRequests(filters: RequestSearchFilters): Promise<RequestSearchResponse> {
-  const response = await api.get<SearchResponseDto | SearchResultDto[]>("/search", {
+  const response = await api.get<SearchResponseDto | SearchResultDto[]>("/search/requests", {
     params: buildSearchParams(filters),
   });
   const results = Array.isArray(response.data) ? response.data : response.data.results ?? [];
+  const normalizedResults = results.map(normalizeSearchResult);
   return {
-    results: results.map(normalizeSearchResult),
+    results: await enrichSearchResultsWithDetail(normalizedResults),
     count: Array.isArray(response.data) ? results.length : response.data.count ?? results.length,
-  };
-}
-
-export function filterLocalSearchResults(
-  results: RequestSearchResult[],
-  filters: RequestSearchFilters,
-): RequestSearchResponse {
-  const query = filters.query.trim().toLowerCase();
-  const filtered = results.filter((result) => {
-    const haystack = [
-      result.id,
-      result.title,
-      result.status,
-      result.assignee,
-      result.flow,
-      result.tags.join(" "),
-      result.snippet,
-    ]
-      .join(" ")
-      .toLowerCase();
-    const updatedTime = Date.parse(result.updatedAt);
-    const fromTime = filters.updatedFrom ? Date.parse(filters.updatedFrom) : Number.NEGATIVE_INFINITY;
-    const toTime = filters.updatedTo ? Date.parse(`${filters.updatedTo}T23:59:59`) : Number.POSITIVE_INFINITY;
-
-    return (
-      (!query || haystack.includes(query)) &&
-      (filters.status.length === 0 || filters.status.includes(result.status)) &&
-      (filters.assignee.length === 0 || filters.assignee.includes(result.assignee)) &&
-      (filters.flow.length === 0 || filters.flow.includes(result.flow)) &&
-      (filters.tag.length === 0 || filters.tag.some((tag) => result.tags.includes(tag))) &&
-      (Number.isNaN(updatedTime) || (updatedTime >= fromTime && updatedTime <= toTime))
-    );
-  });
-
-  const start = (filters.page - 1) * filters.pageSize;
-  return {
-    results: filtered.slice(start, start + filters.pageSize),
-    count: filtered.length,
   };
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -5,7 +5,6 @@ import { HomePage } from "./HomePage";
 import { useAuth } from "../auth/useAuth";
 import { getCurrentUserProfile } from "../auth/userProfile";
 import {
-  filterLocalSearchResults,
   RequestSearchFilters,
   RequestSearchResult,
   searchRequests,
@@ -35,64 +34,6 @@ const EMPTY_SEARCH_FILTERS: RequestSearchFilters = {
   pageSize: 25,
   sort: "-updated_at",
 };
-
-const FALLBACK_SEARCH_RESULTS: RequestSearchResult[] = [
-  {
-    id: "RT-2025-001001",
-    requestId: "RT-2025-001001",
-    title: "VPN not connecting",
-    status: "Open",
-    assignee: "Ana Gomez",
-    flow: "IT Support",
-    tags: ["vpn", "remote-access"],
-    updatedAt: "2025-08-22T10:41:00Z",
-    snippet: "User cannot connect after password rotation. VPN client reports invalid profile.",
-  },
-  {
-    id: "RT-2025-001002",
-    requestId: "RT-2025-001002",
-    title: "Email quota exceeded",
-    status: "In Progress",
-    assignee: "Luis Perez",
-    flow: "Messaging",
-    tags: ["email", "quota"],
-    updatedAt: "2025-08-22T09:18:00Z",
-    snippet: "Mailbox archive job requested before increasing quota.",
-  },
-  {
-    id: "RT-2025-001003",
-    requestId: "RT-2025-001003",
-    title: "Printer F3 queue stuck",
-    status: "Waiting",
-    assignee: "-",
-    flow: "Facilities",
-    tags: ["printer", "floor-3"],
-    updatedAt: "2025-08-21T17:02:00Z",
-    snippet: "Queue is blocked by a failed PDF job. Waiting for onsite confirmation.",
-  },
-  {
-    id: "RT-2025-001004",
-    requestId: "RT-2025-001004",
-    title: "VPN split tunneling",
-    status: "Closed",
-    assignee: "Ana Gomez",
-    flow: "IT Support",
-    tags: ["vpn", "policy"],
-    updatedAt: "2025-08-20T15:27:00Z",
-    snippet: "Policy updated and confirmed with the requester.",
-  },
-  {
-    id: "RT-2025-001005",
-    requestId: "RT-2025-001005",
-    title: "New hire access package",
-    status: "Open",
-    assignee: "Marta Ruiz",
-    flow: "Access Management",
-    tags: ["onboarding", "access"],
-    updatedAt: "2025-08-19T13:10:00Z",
-    snippet: "Manager requested CRM, finance dashboard, and building access.",
-  },
-];
 
 function UserMenu({ onLogout, onProfile }: { onLogout(): void; onProfile(): void }) {
   const menuItems = [
@@ -278,11 +219,12 @@ function SearchResultsTable({
 }) {
   return (
     <div className="card overflow-hidden">
-      <div className="grid grid-cols-[130px_1fr_112px_132px_130px_116px] border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-sm font-semibold text-neutral-600">
+      <div className="grid grid-cols-[130px_1fr_112px_132px_132px_130px_116px] border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-sm font-semibold text-neutral-600">
         <div>ID</div>
         <div>Request</div>
         <div>Status</div>
         <div>Assignee</div>
+        <div>Requester</div>
         <div>Flow</div>
         <div>Updated</div>
       </div>
@@ -295,7 +237,7 @@ function SearchResultsTable({
               if (result.requestId) onOpenRequest(result.requestId);
             }}
             disabled={!result.requestId}
-            className="grid min-h-12 grid-cols-[130px_1fr_112px_132px_130px_116px] items-center border-b border-neutral-100 px-4 py-2 text-left text-sm last:border-b-0 hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-60"
+            className="grid min-h-12 grid-cols-[130px_1fr_112px_132px_132px_130px_116px] items-center border-b border-neutral-100 px-4 py-2 text-left text-sm last:border-b-0 hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <div className="font-semibold text-neutral-800">{result.id}</div>
             <div className="min-w-0 pr-4">
@@ -317,6 +259,7 @@ function SearchResultsTable({
               </span>
             </div>
             <div className="truncate pr-4 text-neutral-700">{result.assignee}</div>
+            <div className="truncate pr-4 text-neutral-700">{result.requester}</div>
             <div className="truncate pr-4 text-neutral-700">{result.flow}</div>
             <div className="text-neutral-700">{result.updatedAt ? formatDate(result.updatedAt) : "-"}</div>
           </button>
@@ -335,22 +278,29 @@ function SearchView() {
     ...EMPTY_SEARCH_FILTERS,
     query: initialQuery,
   });
-  const [results, setResults] = useState<RequestSearchResult[]>(FALLBACK_SEARCH_RESULTS);
-  const [count, setCount] = useState(FALLBACK_SEARCH_RESULTS.length);
+  const [results, setResults] = useState<RequestSearchResult[]>([]);
+  const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const facetSource = results.length > 0 ? results : FALLBACK_SEARCH_RESULTS;
-  const statusValues = uniqueFacetValues(FALLBACK_SEARCH_RESULTS, "status");
-  const assigneeValues = uniqueFacetValues(facetSource, "assignee");
-  const flowValues = uniqueFacetValues(facetSource, "flow");
-  const tagValues = uniqueFacetValues(facetSource, "tag");
+  const statusValues = uniqueFacetValues(results, "status");
+  const assigneeValues = uniqueFacetValues(results, "assignee");
+  const flowValues = uniqueFacetValues(results, "flow");
+  const tagValues = uniqueFacetValues(results, "tag");
   const totalPages = Math.max(1, Math.ceil(count / filters.pageSize));
 
   useEffect(() => {
     let cancelled = false;
 
     async function runSearch() {
+      if (!submittedFilters.query.trim()) {
+        setResults([]);
+        setCount(0);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
       try {
         const response = await searchRequests(submittedFilters);
@@ -360,11 +310,10 @@ function SearchView() {
         setError(null);
       } catch (requestError) {
         if (cancelled) return;
-        const localResponse = filterLocalSearchResults(FALLBACK_SEARCH_RESULTS, submittedFilters);
-        setResults(localResponse.results);
-        setCount(localResponse.count);
+        setResults([]);
+        setCount(0);
         const axiosError = requestError as AxiosError<{ detail?: string }>;
-        setError(axiosError.response?.data?.detail ?? "Showing local search data; API search is unavailable");
+        setError(axiosError.response?.data?.detail ?? "Could not load search results from API.");
       } finally {
         if (!cancelled) {
           setLoading(false);
@@ -378,6 +327,12 @@ function SearchView() {
       cancelled = true;
     };
   }, [submittedFilters]);
+
+  useEffect(() => {
+    const nextFilters = { ...EMPTY_SEARCH_FILTERS, query: initialQuery };
+    setFilters(nextFilters);
+    setSubmittedFilters(nextFilters);
+  }, [initialQuery]);
 
   function updateFilter<K extends keyof RequestSearchFilters>(key: K, value: RequestSearchFilters[K]) {
     setFilters((current) => ({ ...current, [key]: value, page: key === "page" ? current.page : 1 }));
@@ -492,13 +447,15 @@ function SearchView() {
         <div className="space-y-3">
           {loading && <div className="text-sm text-neutral-500">Searching requests...</div>}
           {error && !loading && (
-            <div className="rounded-lg border border-warning-500 bg-white px-4 py-3 text-sm text-neutral-800">
+            <div className="rounded-lg border border-danger-500 bg-white px-4 py-3 text-sm text-danger-500">
               {error}
             </div>
           )}
-          {!loading && results.length === 0 && (
+          {!loading && !error && results.length === 0 && (
             <div className="card border-dashed p-6 text-sm text-neutral-600">
-              No requests matched the current search and facets.
+              {submittedFilters.query.trim()
+                ? "No requests matched the current search and facets."
+                : "Enter a keyword to search requests."}
             </div>
           )}
           {!loading && results.length > 0 && (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -57,71 +57,6 @@ const EMPTY_SUMMARY: DashboardSummary = {
   overdue: 0,
 };
 
-const FALLBACK_REQUESTS: DashboardRequest[] = [
-  {
-    id: "RT-2025-001001",
-    requestId: "RT-2025-001001",
-    title: "VPN not connecting",
-    status: "Open",
-    priority: "High",
-    assignee: "Ana Gomez",
-    requester: "Carlos Diaz",
-    updatedAt: "2025-08-22T10:41:00Z",
-  },
-  {
-    id: "RT-2025-001002",
-    requestId: "RT-2025-001002",
-    title: "Email quota exceeded",
-    status: "In Progress",
-    priority: "Normal",
-    assignee: "Luis Perez",
-    requester: "Maria Lopez",
-    updatedAt: "2025-08-22T09:18:00Z",
-  },
-  {
-    id: "RT-2025-001003",
-    requestId: "RT-2025-001003",
-    title: "Printer F3 queue stuck",
-    status: "Waiting",
-    priority: "Low",
-    assignee: "-",
-    requester: "Nadia Flores",
-    updatedAt: "2025-08-21T17:02:00Z",
-  },
-  {
-    id: "RT-2025-001004",
-    requestId: "RT-2025-001004",
-    title: "VPN split tunneling",
-    status: "Closed",
-    priority: "Normal",
-    assignee: "Ana Gomez",
-    requester: "Rafael Cruz",
-    updatedAt: "2025-08-20T15:27:00Z",
-  },
-];
-
-function filterFallbackRequests(tab: DashboardListKey, quickFilter: QuickFilter | "") {
-  let requests = [...FALLBACK_REQUESTS];
-  if (tab === "my_tasks") requests = requests.filter((request) => request.assignee === "Ana Gomez");
-  if (tab === "other_tasks") requests = requests.filter((request) => request.assignee !== "Ana Gomez");
-  if (tab === "my_requests") requests = requests.filter((request) => request.requester === "Carlos Diaz");
-
-  if (quickFilter === "my_open") {
-    requests = requests.filter((request) => request.assignee === "Ana Gomez" && request.status !== "Closed");
-  }
-  if (quickFilter === "high_priority") {
-    requests = requests.filter((request) => request.priority.toLowerCase() === "high");
-  }
-  if (quickFilter === "closed") {
-    requests = requests.filter((request) => request.status === "Closed");
-  }
-  if (quickFilter === "unassigned") {
-    requests = requests.filter((request) => request.assignee === "-");
-  }
-
-  return requests;
-}
-
 export function HomePage() {
   const navigate = useNavigate();
   const [summary, setSummary] = useState<DashboardSummary>(EMPTY_SUMMARY);
@@ -162,10 +97,9 @@ export function HomePage() {
       setRequestCount(response.count);
       setListError(null);
     } catch {
-      const fallbackRequests = filterFallbackRequests(activeTab, quickFilter);
-      setRequests(fallbackRequests);
-      setRequestCount(fallbackRequests.length);
-      setListError("Could not load dashboard from API. Showing local demo data.");
+      setRequests([]);
+      setRequestCount(0);
+      setListError("Could not load dashboard requests from API.");
     } finally {
       setListLoading(false);
     }
@@ -239,6 +173,13 @@ export function HomePage() {
         />
         <button type="submit" className="btn btn-primary">
           Search
+        </button>
+        <button
+          type="button"
+          onClick={() => setSearch("")}
+          className="rounded-lg border border-neutral-300 px-4 text-sm font-semibold text-neutral-700 hover:bg-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-600"
+        >
+          Clear
         </button>
       </form>
 

--- a/src/pages/RequestDetailPage.tsx
+++ b/src/pages/RequestDetailPage.tsx
@@ -16,7 +16,7 @@ import { EmptyState } from "../components/common/EmptyState";
 import { ErrorState } from "../components/common/ErrorState";
 import { PriorityChip } from "../components/requests/PriorityChip";
 import { StatusBadge } from "../components/requests/StatusBadge";
-import { RequestComment } from "../features/requestActivity";
+import { createRequestComment, RequestComment } from "../features/requestActivity";
 
 const FALLBACK_DETAIL: RequestDetail = {
   id: "RT-2025-001001",
@@ -155,6 +155,79 @@ function CommentsSection({ comments }: { comments: RequestComment[] }) {
           )}
         </article>
       ))}
+    </div>
+  );
+}
+
+function UploadSection({
+  comment,
+  files,
+  inputKey,
+  submitting,
+  error,
+  success,
+  onCommentChange,
+  onFilesChange,
+  onSubmit,
+}: {
+  comment: string;
+  files: File[];
+  inputKey: number;
+  submitting: boolean;
+  error: string | null;
+  success: string | null;
+  onCommentChange(comment: string): void;
+  onFilesChange(files: File[]): void;
+  onSubmit(): void;
+}) {
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="rounded-lg border border-danger-500 bg-white px-3 py-2 text-sm font-semibold text-danger-500">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-lg border border-primary-600 bg-primary-50 px-3 py-2 text-sm font-semibold text-primary-700">
+          {success}
+        </div>
+      )}
+      <div>
+        <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="upload-comment">
+          Comment
+        </label>
+        <textarea
+          id="upload-comment"
+          value={comment}
+          onChange={(event) => onCommentChange(event.target.value)}
+          className="min-h-24 w-full resize-y rounded-lg border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none focus:border-primary-600 focus:ring-2 focus:ring-primary-50"
+          placeholder="Add context for the uploaded files."
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-sm font-semibold text-neutral-700" htmlFor="upload-files">
+          Attach files
+        </label>
+        <input
+          key={inputKey}
+          id="upload-files"
+          type="file"
+          multiple
+          onChange={(event) => onFilesChange(Array.from(event.target.files ?? []))}
+          className="block w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 file:mr-3 file:rounded-lg file:border-0 file:bg-neutral-100 file:px-3 file:py-1 file:text-sm file:font-semibold file:text-neutral-700 focus:outline-none focus:ring-2 focus:ring-primary-50"
+        />
+        <div className="mt-1 text-xs text-neutral-500">
+          {files.length > 0 ? `${files.length} selected` : "Multiple files are grouped into one comment."}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={onSubmit}
+        disabled={submitting || (!comment.trim() && files.length === 0)}
+      >
+        {submitting ? "Uploading" : "Add Comment / Upload"}
+      </button>
     </div>
   );
 }
@@ -428,6 +501,12 @@ export default function RequestDetailPage() {
   const [assignmentError, setAssignmentError] = useState<string | null>(null);
   const [assignmentSuccess, setAssignmentSuccess] = useState<string | null>(null);
   const [usersLoadAttempt, setUsersLoadAttempt] = useState(0);
+  const [uploadComment, setUploadComment] = useState("");
+  const [uploadFiles, setUploadFiles] = useState<File[]>([]);
+  const [uploadSubmitting, setUploadSubmitting] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
+  const [uploadInputKey, setUploadInputKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -579,6 +658,30 @@ export default function RequestDetailPage() {
     }
   }
 
+  async function submitUpload() {
+    if (!requestId) return;
+    if (!uploadComment.trim() && uploadFiles.length === 0) {
+      setUploadError("Add a comment or choose at least one file.");
+      return;
+    }
+
+    setUploadSubmitting(true);
+    setUploadError(null);
+    setUploadSuccess(null);
+    try {
+      await createRequestComment(requestId, uploadComment.trim(), uploadFiles);
+      setUploadComment("");
+      setUploadFiles([]);
+      setUploadInputKey((current) => current + 1);
+      setUploadSuccess(uploadFiles.length > 0 ? "Upload submitted." : "Comment added.");
+      setLoadAttempt((current) => current + 1);
+    } catch (requestError) {
+      setUploadError(formatApiError(requestError, "Could not add comment or upload files. Please try again."));
+    } finally {
+      setUploadSubmitting(false);
+    }
+  }
+
   if (!detail && loading) {
     return <div className="p-6 text-sm text-neutral-500">Loading request detail...</div>;
   }
@@ -627,6 +730,27 @@ export default function RequestDetailPage() {
 
           <section className="card p-4">
             <h2 className="text-lg font-semibold text-neutral-900">Comments</h2>
+            <div className="mt-3 border-b border-neutral-200 pb-4">
+              <UploadSection
+                comment={uploadComment}
+                files={uploadFiles}
+                inputKey={uploadInputKey}
+                submitting={uploadSubmitting}
+                error={uploadError}
+                success={uploadSuccess}
+                onCommentChange={(value) => {
+                  setUploadComment(value);
+                  setUploadError(null);
+                  setUploadSuccess(null);
+                }}
+                onFilesChange={(files) => {
+                  setUploadFiles(files);
+                  setUploadError(null);
+                  setUploadSuccess(null);
+                }}
+                onSubmit={submitUpload}
+              />
+            </div>
             <div className="mt-3">
               <CommentsSection comments={comments} />
             </div>


### PR DESCRIPTION
## Summary
- fixes Home search navigation and adds a clear action
- switches Search to GET /search/requests and removes local demo fallback rows
- normalizes request display fields and enriches Home/Search rows from Request Detail when list/search responses only include IDs
- loads Request Detail attachments from the attachments endpoint
- adds grouped comment/file upload using attachments init, presigned PUT, and finalize
- updates the Sprint 2 ExecPlan with Day 10 hardening notes

## Verification
- pnpm lint could not run because pnpm is not installed on PATH
- pnpm build could not run because pnpm is not installed on PATH
- .\\node_modules\\.bin\\tsc.CMD --noEmit
- .\\node_modules\\.bin\\eslint.CMD .
- .\\node_modules\\.bin\\vite.CMD build
- npm.cmd run typecheck
- npm.cmd run lint
- npm.cmd run build
- built SPA smoke: /search?q=vpn returned 200 and /requests/{id} returned 200